### PR TITLE
SYS-1178: Basic item search interface

### DIFF
--- a/oh_staff_ui/forms.py
+++ b/oh_staff_ui/forms.py
@@ -12,3 +12,11 @@ class ProjectItemForm(forms.Form):
     sequence = forms.CharField(
         required=True, max_length=3, widget=forms.TextInput(attrs={"size": 3})
     )
+
+
+class ItemSearchForm(forms.Form):
+    search_types = [("ark", "ARK"), ("title", "Title")]
+    search_type = forms.ChoiceField(choices=search_types)
+    query = forms.CharField(
+        required=True, max_length=256, widget=forms.TextInput(attrs={"size": 80})
+    )

--- a/oh_staff_ui/templates/oh_staff_ui/base.html
+++ b/oh_staff_ui/templates/oh_staff_ui/base.html
@@ -7,7 +7,7 @@
 </head>
 
 <body>
-    <p>Temporary: <a href="/admin/">Admin</a>&nbsp;<a href="/admin/logout/">Logout</a></p>
+    <p>Temporary: <a href="/item_search/">Search</a>&nbsp;<a href="/admin/">Admin</a>&nbsp;<a href="/admin/logout/">Logout</a></p>
     {% block content %}
     {% endblock %}
 </body>

--- a/oh_staff_ui/templates/oh_staff_ui/base.html
+++ b/oh_staff_ui/templates/oh_staff_ui/base.html
@@ -3,7 +3,7 @@
 <html>
 
 <head>
-    <!-- <link rel="stylesheet" type="text/css" href="{% static 'css/custom.css' %}"/> -->
+<link rel="stylesheet" type="text/css" href="{% static 'css/style.css' %}"/>
 </head>
 
 <body>

--- a/oh_staff_ui/templates/oh_staff_ui/item_search.html
+++ b/oh_staff_ui/templates/oh_staff_ui/item_search.html
@@ -1,0 +1,12 @@
+{% extends 'oh_staff_ui/base.html' %}
+
+{% block content %}
+<form name="item_search" id="item_search" method="POST">
+    {% csrf_token %}
+    <table>
+        {{ form.as_table }}
+    </table>
+    <br>
+    <button type="submit">Search</button>
+</form>
+{% endblock %}

--- a/oh_staff_ui/templates/oh_staff_ui/search_results.html
+++ b/oh_staff_ui/templates/oh_staff_ui/search_results.html
@@ -2,15 +2,15 @@
 
 {% block content %}
 {% if results %}
-<table style="width: 100%">
+<table class="search-results">
     <tr>
         <th>ARK</th>
         <th>Title</th>
     </tr>
     {% for item in results %}
     <tr>
-        <td style="border: 1px solid"><a href="{% url 'edit_item' item.id %}">{{ item.ark }}</a></td>
-        <td style="border: 1px solid">{{ item.title}}</td>
+        <td><a href="{% url 'edit_item' item.id %}">{{ item.ark }}</a></td>
+        <td>{{ item.title}}</td>
     </tr>
     {% endfor %}
 </table>

--- a/oh_staff_ui/templates/oh_staff_ui/search_results.html
+++ b/oh_staff_ui/templates/oh_staff_ui/search_results.html
@@ -1,0 +1,21 @@
+{% extends 'oh_staff_ui/base.html' %}
+
+{% block content %}
+{% if results %}
+<table style="width: 100%">
+    <tr>
+        <th>ARK</th>
+        <th>Title</th>
+    </tr>
+    {% for item in results %}
+    <tr>
+        <td style="border: 1px solid"><a href="{% url 'edit_item' item.id %}">{{ item.ark }}</a></td>
+        <td style="border: 1px solid">{{ item.title}}</td>
+    </tr>
+    {% endfor %}
+</table>
+{% else %}
+<p>No results found.</p>
+{% endif %}
+
+{% endblock %}

--- a/oh_staff_ui/urls.py
+++ b/oh_staff_ui/urls.py
@@ -5,4 +5,10 @@ urlpatterns = [
     path("add_item/", views.add_item, name="add_item"),
     path("item/<int:item_id>", views.edit_item, name="edit_item"),
     path("", views.add_item),  # TODO: Change this to something better.....
+    path("item_search/", views.item_search, name="item_search"),
+    path(
+        "search_results/<str:search_type>/<str:query>",
+        views.search_results,
+        name="search_results",
+    ),
 ]

--- a/oh_staff_ui/views.py
+++ b/oh_staff_ui/views.py
@@ -4,6 +4,7 @@ from django.http.request import HttpRequest  # for code completion
 from django.http.response import HttpResponse  # for code completion
 from oh_staff_ui.forms import ProjectItemForm, ItemSearchForm
 from oh_staff_ui.models import ProjectItem
+from .views_utils import *
 
 
 @login_required
@@ -59,11 +60,8 @@ def item_search(request: HttpRequest) -> HttpResponse:
 @login_required
 def search_results(request: HttpRequest, search_type: str, query: str) -> HttpResponse:
     if search_type == "title":
-        results = (
-            ProjectItem.objects.filter(title__icontains=query)
-            .order_by("title")
-            .values()
-        )
+        full_query = construct_keyword_query(query)
+        results = ProjectItem.objects.filter(full_query).order_by("title").values()
     elif search_type == "ark":
         results = (
             ProjectItem.objects.filter(ark__icontains=query).order_by("ark").values()

--- a/oh_staff_ui/views.py
+++ b/oh_staff_ui/views.py
@@ -2,7 +2,7 @@ from django.shortcuts import redirect, render
 from django.contrib.auth.decorators import login_required
 from django.http.request import HttpRequest  # for code completion
 from django.http.response import HttpResponse  # for code completion
-from oh_staff_ui.forms import ProjectItemForm
+from oh_staff_ui.forms import ProjectItemForm, ItemSearchForm
 from oh_staff_ui.models import ProjectItem
 
 
@@ -39,3 +39,33 @@ def edit_item(request: HttpRequest, item_id: int) -> HttpResponse:
     # TODO: Real form, and view, for editing item and its associated metadata.
     item = ProjectItem.objects.get(pk=item_id)
     return render(request, "oh_staff_ui/edit_item.html", {"item": item})
+
+
+@login_required
+def item_search(request: HttpRequest) -> HttpResponse:
+    if request.method == "POST":
+        form = ItemSearchForm(request.POST)
+        if form.is_valid():
+            return redirect(
+                "search_results",
+                search_type=form.cleaned_data["search_type"],
+                query=form.cleaned_data["query"],
+            )
+    else:
+        form = ItemSearchForm()
+        return render(request, "oh_staff_ui/item_search.html", {"form": form})
+
+
+@login_required
+def search_results(request: HttpRequest, search_type: str, query: str) -> HttpResponse:
+    if search_type == "title":
+        results = (
+            ProjectItem.objects.filter(title__icontains=query)
+            .order_by("title")
+            .values()
+        )
+    elif search_type == "ark":
+        results = (
+            ProjectItem.objects.filter(ark__icontains=query).order_by("ark").values()
+        )
+    return render(request, "oh_staff_ui/search_results.html", {"results": results})

--- a/oh_staff_ui/views_utils.py
+++ b/oh_staff_ui/views_utils.py
@@ -2,9 +2,16 @@ from django.db.models import Q
 
 
 def construct_keyword_query(query: str) -> Q:
+    # Always include the full query, as a single substring.
     full_q = Q(title__icontains=query)
     keywords = query.split()
-    for word in keywords:
-        q_obj = Q(title__icontains=word)
-        full_q = full_q | q_obj
+    # If there's only one word, it's the same as the full query, nothing to do.
+    # Otherwise, grab the first word, then AND each following word.
+    if len(keywords) > 1:
+        words_q = Q(title__icontains=keywords[0])
+        # All except the first word
+        for word in keywords[1:]:
+            words_q = words_q & Q(title__icontains=word)
+        # OR the assembled set of words with the full query.
+        full_q = full_q | words_q
     return full_q

--- a/oh_staff_ui/views_utils.py
+++ b/oh_staff_ui/views_utils.py
@@ -1,0 +1,10 @@
+from django.db.models import Q
+
+
+def construct_keyword_query(query: str) -> Q:
+    full_q = Q(title__icontains=query)
+    keywords = query.split()
+    for word in keywords:
+        q_obj = Q(title__icontains=word)
+        full_q = full_q | q_obj
+    return full_q

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1,0 +1,7 @@
+.search-results {
+   width: 100%;
+}
+
+.search-results td {
+    border: 1px solid;
+}


### PR DESCRIPTION
Implements [SYS-1178](https://jira.library.ucla.edu/browse/SYS-1178)

Creates basic search functionality for ProjectItems. After login, the search form (http://127.0.0.1:8000/item_search/) allows users to search by ARK or Title, finding case-insensitive substring matches for each. The results are displayed on a new search_results page, sorted alphabetically by ARK or Title depending on the type of search performed. Each result ARK contains a link to the corresponding /item/item_id page.

Let me know if we should have more/different functionality at this stage (different types of result sort or search matching? more Item metadata in the results display?) - thanks!