### PR TITLE
SYS-1179: Add support for item editing

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ The container runs via `docker_scripts/entrypoint.sh`, which
 * Waits for the database to be completely available.  This can take 5-10 seconds, depending on your hardware.
 * Applies any pending migrations (DEV environment only).
 * Creates a generic Django superuser, if one does not already exist (DEV environment only).
+* Loads fixtures to populate lookup tables and to add a few sample records.
 * Starts the Django application server.
 
 ### Setup
@@ -77,6 +78,11 @@ The container runs via `docker_scripts/entrypoint.sh`, which
    $ docker-compose exec django python manage.py migrate
    # Populate database with seed data (once it exists...)
    $ docker-compose exec django python manage.py loaddata --app oh_staff_ui seed-data
+   #
+   # Load full set of item data
+   $ docker-compose exec django python manage.py import_projectitems oh-projectitems-export-3.csv
+   # Load full set of name data
+   $ docker-compose exec django python manage.py import_names name-md-export.csv
    ```
 7. Connect to the running application via browser
 

--- a/oh_staff_ui/forms.py
+++ b/oh_staff_ui/forms.py
@@ -1,5 +1,5 @@
 from django import forms
-from oh_staff_ui.models import ItemType
+from oh_staff_ui.models import ItemType, Name, NameType, Subject, SubjectType
 
 
 class ProjectItemForm(forms.Form):
@@ -20,3 +20,31 @@ class ItemSearchForm(forms.Form):
     query = forms.CharField(
         required=True, max_length=256, widget=forms.TextInput(attrs={"size": 80})
     )
+
+
+class NameUsage(forms.Form):
+    type = forms.ModelChoiceField(
+        queryset=NameType.objects.all().order_by("type"),
+        empty_label="Please select a qualifier:",
+    )
+    name = forms.ModelChoiceField(
+        queryset=Name.objects.all().order_by("value"),
+        empty_label="Please select a name:",
+    )
+
+
+NameUsageFormset = forms.formset_factory(NameUsage, extra=1, can_delete=True)
+
+
+class SubjectUsage(forms.Form):
+    type = forms.ModelChoiceField(
+        queryset=SubjectType.objects.all().order_by("type"),
+        empty_label="Please select a qualifier:",
+    )
+    subject = forms.ModelChoiceField(
+        queryset=Subject.objects.all().order_by("value"),
+        empty_label="Please select a subject:",
+    )
+
+
+SubjectUsageFormset = forms.formset_factory(SubjectUsage, extra=1, can_delete=True)

--- a/oh_staff_ui/forms.py
+++ b/oh_staff_ui/forms.py
@@ -3,6 +3,8 @@ from oh_staff_ui.models import (
     ItemType,
     Name,
     NameType,
+    Subject,
+    SubjectType,
 )
 
 
@@ -38,15 +40,13 @@ class NameUsageForm(forms.Form):
     )
 
 
-# class SubjectUsage(forms.Form):
-#     type = forms.ModelChoiceField(
-#         queryset=SubjectType.objects.all().order_by("type"),
-#         empty_label="Please select a qualifier:",
-#     )
-#     subject = forms.ModelChoiceField(
-#         queryset=Subject.objects.all().order_by("value"),
-#         empty_label="Please select a subject:",
-#     )
-
-
-# SubjectUsageFormset = forms.formset_factory(SubjectUsage, extra=1, can_delete=True)
+class SubjectUsageForm(forms.Form):
+    usage_id = forms.IntegerField(initial=0, widget=forms.HiddenInput())
+    type = forms.ModelChoiceField(
+        queryset=SubjectType.objects.all().order_by("type"),
+        empty_label="Please select a qualifier:",
+    )
+    subject = forms.ModelChoiceField(
+        queryset=Subject.objects.all().order_by("value"),
+        empty_label="Please select a subject:",
+    )

--- a/oh_staff_ui/forms.py
+++ b/oh_staff_ui/forms.py
@@ -1,5 +1,9 @@
 from django import forms
-from oh_staff_ui.models import ItemType, Name, NameType, Subject, SubjectType
+from oh_staff_ui.models import (
+    ItemType,
+    Name,
+    NameType,
+)
 
 
 class ProjectItemForm(forms.Form):
@@ -22,7 +26,8 @@ class ItemSearchForm(forms.Form):
     )
 
 
-class NameUsage(forms.Form):
+class NameUsageForm(forms.Form):
+    usage_id = forms.IntegerField(initial=0, widget=forms.HiddenInput())
     type = forms.ModelChoiceField(
         queryset=NameType.objects.all().order_by("type"),
         empty_label="Please select a qualifier:",
@@ -33,18 +38,15 @@ class NameUsage(forms.Form):
     )
 
 
-NameUsageFormset = forms.formset_factory(NameUsage, extra=1, can_delete=True)
+# class SubjectUsage(forms.Form):
+#     type = forms.ModelChoiceField(
+#         queryset=SubjectType.objects.all().order_by("type"),
+#         empty_label="Please select a qualifier:",
+#     )
+#     subject = forms.ModelChoiceField(
+#         queryset=Subject.objects.all().order_by("value"),
+#         empty_label="Please select a subject:",
+#     )
 
 
-class SubjectUsage(forms.Form):
-    type = forms.ModelChoiceField(
-        queryset=SubjectType.objects.all().order_by("type"),
-        empty_label="Please select a qualifier:",
-    )
-    subject = forms.ModelChoiceField(
-        queryset=Subject.objects.all().order_by("value"),
-        empty_label="Please select a subject:",
-    )
-
-
-SubjectUsageFormset = forms.formset_factory(SubjectUsage, extra=1, can_delete=True)
+# SubjectUsageFormset = forms.formset_factory(SubjectUsage, extra=1, can_delete=True)

--- a/oh_staff_ui/models.py
+++ b/oh_staff_ui/models.py
@@ -105,7 +105,7 @@ class Name(models.Model):
     )
 
     def __str__(self):
-        return self.value
+        return f"{self.value} ({self.source})"
 
 
 class ItemNameUsage(models.Model):

--- a/oh_staff_ui/templates/oh_staff_ui/edit_item.html
+++ b/oh_staff_ui/templates/oh_staff_ui/edit_item.html
@@ -4,18 +4,27 @@
 <p>The form for editing an item and its added metadata will go here</p>
 <ul>
     <li>id: {{ item.id }}</li>
-    <li>title: {{ item.title }}</li>
     <li>ARK: {{ item.ark }}</li>
-    <li>create_date: {{ item.create_date }}</li>
+    <li>created: {{ item.create_date }} by {{ item.created_by }}</li>
+    <li>updated: {{ item.last_modified_date }} by {{ item.last_modified_by }}</li>
 </ul>
-{{ item_form.as_div }}
-<br>
-<table>
-    {{ name_formset.as_table }}
-</table>
-<br>
-<table>
-    {{ subject_formset.as_table }}
-</table>
+<form name="edit_item" id="edit_item" method="POST">
+    {% csrf_token %}
+    {{ item_form.as_div }}
+    <br>
+    {{ name_formset.management_form }}
+    <table>
+        {% for name_form in name_formset %}
+        <tr>
+            <td>{% if forloop.first %}Name(s):{% endif %}</td>
+            <td>{{ name_form.usage_id }} {{ name_form.type }}</td>
+            <td>{{ name_form.name }}</td>
+            <td>Delete? {{ name_form.DELETE }}</td>
+        </tr>
+        {% endfor %}
+    </table>
+    <br>
+    <button type="submit">Save</button>
+</form>
 {% endblock %}
 

--- a/oh_staff_ui/templates/oh_staff_ui/edit_item.html
+++ b/oh_staff_ui/templates/oh_staff_ui/edit_item.html
@@ -5,8 +5,17 @@
 <ul>
     <li>id: {{ item.id }}</li>
     <li>title: {{ item.title }}</li>
+    <li>ARK: {{ item.ark }}</li>
     <li>create_date: {{ item.create_date }}</li>
 </ul>
-
+{{ item_form.as_div }}
+<br>
+<table>
+    {{ name_formset.as_table }}
+</table>
+<br>
+<table>
+    {{ subject_formset.as_table }}
+</table>
 {% endblock %}
 

--- a/oh_staff_ui/templates/oh_staff_ui/edit_item.html
+++ b/oh_staff_ui/templates/oh_staff_ui/edit_item.html
@@ -1,7 +1,6 @@
 {% extends 'oh_staff_ui/base.html' %}
 
 {% block content %}
-<p>The form for editing an item and its added metadata will go here</p>
 <ul>
     <li>id: {{ item.id }}</li>
     <li>ARK: {{ item.ark }}</li>
@@ -13,6 +12,7 @@
     {{ item_form.as_div }}
     <br>
     {{ name_formset.management_form }}
+    {{ subject_formset.management_form }}
     <table>
         {% for name_form in name_formset %}
         <tr>
@@ -20,6 +20,14 @@
             <td>{{ name_form.usage_id }} {{ name_form.type }}</td>
             <td>{{ name_form.name }}</td>
             <td>Delete? {{ name_form.DELETE }}</td>
+        </tr>
+        {% endfor %}
+        {% for subject_form in subject_formset %}
+        <tr>
+            <td>{% if forloop.first %}Subject(s):{% endif %}</td>
+            <td>{{ subject_form.usage_id }} {{ subject_form.type }}</td>
+            <td>{{ subject_form.subject }}</td>
+            <td>Delete? {{ subject_form.DELETE }}</td>
         </tr>
         {% endfor %}
     </table>

--- a/oh_staff_ui/views.py
+++ b/oh_staff_ui/views.py
@@ -47,10 +47,12 @@ def add_item(request: HttpRequest) -> HttpResponse:
 
 @login_required
 def edit_item(request: HttpRequest, item_id: int) -> HttpResponse:
+    logger.info("\n==========================================")
     if request.method == "POST":
+        logger.info(f"REQUEST.POST: {request.POST}")
         save_all_item_data(item_id, request)
     context = get_edit_item_context(item_id)
-    logger.info(f"{context=}")
+    logger.info(f"CONTEXT: {context}")
     return render(request, "oh_staff_ui/edit_item.html", context)
 
 

--- a/oh_staff_ui/views.py
+++ b/oh_staff_ui/views.py
@@ -2,9 +2,14 @@ from django.shortcuts import redirect, render
 from django.contrib.auth.decorators import login_required
 from django.http.request import HttpRequest  # for code completion
 from django.http.response import HttpResponse  # for code completion
-from oh_staff_ui.forms import ProjectItemForm, ItemSearchForm
+from oh_staff_ui.forms import (
+    ProjectItemForm,
+    ItemSearchForm,
+    NameUsageFormset,
+    SubjectUsageFormset,
+)
 from oh_staff_ui.models import ProjectItem
-from .views_utils import *
+from oh_staff_ui.views_utils import construct_keyword_query
 
 
 @login_required
@@ -39,7 +44,25 @@ def add_item(request: HttpRequest) -> HttpResponse:
 def edit_item(request: HttpRequest, item_id: int) -> HttpResponse:
     # TODO: Real form, and view, for editing item and its associated metadata.
     item = ProjectItem.objects.get(pk=item_id)
-    return render(request, "oh_staff_ui/edit_item.html", {"item": item})
+    if request.method == "POST":
+        # item_form = ProjectItemForm(request.POST)
+        pass
+    else:
+        # TODO: Get data via utility functions
+        data = {"title": item.title, "type": item.type, "sequence": item.sequence}
+        item_form = ProjectItemForm(data)
+        name_formset = NameUsageFormset(prefix="names")
+        subject_formset = SubjectUsageFormset(prefix="subjects")
+    return render(
+        request,
+        "oh_staff_ui/edit_item.html",
+        {
+            "item": item,
+            "item_form": item_form,
+            "name_formset": name_formset,
+            "subject_formset": subject_formset,
+        },
+    )
 
 
 @login_required

--- a/oh_staff_ui/views.py
+++ b/oh_staff_ui/views.py
@@ -1,3 +1,4 @@
+import logging
 from django.shortcuts import redirect, render
 from django.contrib.auth.decorators import login_required
 from django.http.request import HttpRequest  # for code completion
@@ -5,11 +6,15 @@ from django.http.response import HttpResponse  # for code completion
 from oh_staff_ui.forms import (
     ProjectItemForm,
     ItemSearchForm,
-    NameUsageFormset,
-    SubjectUsageFormset,
 )
 from oh_staff_ui.models import ProjectItem
-from oh_staff_ui.views_utils import construct_keyword_query
+from oh_staff_ui.views_utils import (
+    construct_keyword_query,
+    get_edit_item_context,
+    save_all_item_data,
+)
+
+logger = logging.getLogger(__name__)
 
 
 @login_required
@@ -42,27 +47,11 @@ def add_item(request: HttpRequest) -> HttpResponse:
 
 @login_required
 def edit_item(request: HttpRequest, item_id: int) -> HttpResponse:
-    # TODO: Real form, and view, for editing item and its associated metadata.
-    item = ProjectItem.objects.get(pk=item_id)
     if request.method == "POST":
-        # item_form = ProjectItemForm(request.POST)
-        pass
-    else:
-        # TODO: Get data via utility functions
-        data = {"title": item.title, "type": item.type, "sequence": item.sequence}
-        item_form = ProjectItemForm(data)
-        name_formset = NameUsageFormset(prefix="names")
-        subject_formset = SubjectUsageFormset(prefix="subjects")
-    return render(
-        request,
-        "oh_staff_ui/edit_item.html",
-        {
-            "item": item,
-            "item_form": item_form,
-            "name_formset": name_formset,
-            "subject_formset": subject_formset,
-        },
-    )
+        save_all_item_data(item_id, request)
+    context = get_edit_item_context(item_id)
+    logger.info(f"{context=}")
+    return render(request, "oh_staff_ui/edit_item.html", context)
 
 
 @login_required

--- a/oh_staff_ui/views_utils.py
+++ b/oh_staff_ui/views_utils.py
@@ -1,10 +1,10 @@
 import logging
 from django.db.models import Q
-from django.forms import formset_factory
+from django.forms import BaseFormSet, formset_factory
 from django.http.request import HttpRequest  # for code completion
 from django.utils import timezone
-from oh_staff_ui.forms import ProjectItemForm, NameUsageForm
-from oh_staff_ui.models import ProjectItem, ItemNameUsage
+from oh_staff_ui.forms import ProjectItemForm, NameUsageForm, SubjectUsageForm
+from oh_staff_ui.models import ProjectItem, ItemNameUsage, ItemSubjectUsage
 
 logger = logging.getLogger(__name__)
 
@@ -25,26 +25,27 @@ def construct_keyword_query(query: str) -> Q:
     return full_q
 
 
-def get_all_item_data(item_id: int) -> dict:
+def get_edit_item_context(item_id: int) -> dict:
+    # Populate forms with data from database
     item = ProjectItem.objects.get(pk=item_id)
-    names = ItemNameUsage.objects.filter(item=item_id).order_by("id")
+    # item_form is "bound" with this data
+    item_form = ProjectItemForm(
+        data={"title": item.title, "type": item.type, "sequence": item.sequence}
+    )
+    name_formset = get_name_formset(item_id)
+    subject_formset = get_subject_formset(item_id)
     return {
         "item": item,
-        "names": names,
+        "item_form": item_form,
+        "name_formset": name_formset,
+        "subject_formset": subject_formset,
     }
 
 
-def get_edit_item_context(item_id: int) -> dict:
+def get_name_formset(item_id: int) -> BaseFormSet:
     NameUsageFormset = formset_factory(NameUsageForm, extra=1, can_delete=True)
-    # Populate forms with data from database
-    item_data = get_all_item_data(item_id)
-    logger.info(f"{item_data=}")
-    item = item_data["item"]
-    names = item_data["names"]
-    item_form = ProjectItemForm(
-        {"title": item.title, "type": item.type, "sequence": item.sequence}
-    )
-    # Formset needs list of dictionaries of initial values.
+    # Build list of dictionaries of initial values.
+    names = ItemNameUsage.objects.filter(item=item_id).order_by("id")
     name_list = []
     for name in names:
         name_list.append(
@@ -54,23 +55,41 @@ def get_edit_item_context(item_id: int) -> dict:
                 "name": name.name,
             }
         )
+    # name_formset is "unbound" with this initial data
     name_formset = NameUsageFormset(initial=name_list, prefix="names")
-    return {
-        "item": item,
-        "item_form": item_form,
-        "name_formset": name_formset,
-    }
+    return name_formset
+
+
+def get_subject_formset(item_id: int) -> BaseFormSet:
+    SubjectUsageFormset = formset_factory(SubjectUsageForm, extra=1, can_delete=True)
+    # Build list of dictionaries of initial values.
+    subjects = ItemSubjectUsage.objects.filter(item=item_id).order_by("id")
+    subject_list = []
+    for subject in subjects:
+        subject_list.append(
+            {
+                "usage_id": subject.id,
+                "type": subject.type,
+                "subject": subject.subject,
+            }
+        )
+    # subject_formset is "unbound" with this initial data
+    subject_formset = SubjectUsageFormset(initial=subject_list, prefix="subjects")
+    return subject_formset
 
 
 def save_all_item_data(item_id: int, request: HttpRequest) -> None:
     NameUsageFormset = formset_factory(NameUsageForm, extra=1, can_delete=True)
+    SubjectUsageFormset = formset_factory(SubjectUsageForm, extra=1, can_delete=True)
     item_form = ProjectItemForm(request.POST)
     name_formset = NameUsageFormset(request.POST, prefix="names")
+    subject_formset = SubjectUsageFormset(request.POST, prefix="subjects")
 
-    if item_form.is_valid() & name_formset.is_valid():
+    if item_form.is_valid() & name_formset.is_valid() & subject_formset.is_valid():
         logger.info(f"Saving data for item {item_id}")
-        logger.info(item_form.cleaned_data)
-        logger.info(name_formset.cleaned_data)
+        logger.info(f"ITEM: {item_form.cleaned_data}")
+        logger.info(f"NAMES: {name_formset.cleaned_data}")
+        logger.info(f"SUBJECTS: {subject_formset.cleaned_data}")
         # Item data
         item = ProjectItem.objects.get(pk=item_id)
         item.sequence = item_form.cleaned_data["sequence"]
@@ -79,20 +98,64 @@ def save_all_item_data(item_id: int, request: HttpRequest) -> None:
         item.last_modified_date = timezone.now()
         item.last_modified_by = request.user
         item.save()
-        # Name usage data
-        for name_usage_data in name_formset.cleaned_data:
-            # List of dictionaries, some/all of which can be empty
-            if name_usage_data:
-                name_usage = ItemNameUsage(
-                    name=name_usage_data["name"],
-                    type=name_usage_data["type"],
-                    item=item,
-                )
-                if name_usage_data["usage_id"] > 0:
-                    name_usage.id = name_usage_data["usage_id"]
-                if name_usage_data["DELETE"]:
-                    # Only delete if record already exists; otherwise, just don't save
-                    if name_usage.id:
-                        name_usage.delete()
-                else:
-                    name_usage.save()
+        # Other, optional, metadata types
+        save_item_names(item, name_formset.cleaned_data)
+        save_item_subjects(item, subject_formset.cleaned_data)
+
+
+def valid_metadata_usage(usage_data: dict) -> bool:
+    # Check metadata "usage" form for valid data.
+
+    # Reject empty dictionary from unused form.
+    if not usage_data:
+        return False
+    # Reject unused form where user checked Delete box.
+    if usage_data["usage_id"] == 0 and usage_data["DELETE"]:
+        return False
+
+    # Made it to here, form data is OK
+    return True
+
+
+# TODO: Refactor save_item_XXXX() to minimize similar/identical code
+def save_item_names(item: ProjectItem, name_formset_data: list) -> None:
+    # List of dictionaries, some/all of which can be empty
+    for name_usage_data in name_formset_data:
+        if valid_metadata_usage(name_usage_data):
+            # Populate object
+            name_usage = ItemNameUsage(
+                name=name_usage_data["name"],
+                type=name_usage_data["type"],
+                item=item,
+            )
+            # Existing object with real id
+            if name_usage_data["usage_id"] > 0:
+                name_usage.id = name_usage_data["usage_id"]
+            # Only delete if record already exists; otherwise, just don't save
+            if name_usage_data["DELETE"]:
+                if name_usage.id:
+                    name_usage.delete()
+            else:
+                name_usage.save()
+
+
+# TODO: Refactor save_item_XXXX() to minimize similar/identical code
+def save_item_subjects(item: ProjectItem, subject_formset_data: list) -> None:
+    # List of dictionaries, some/all of which can be empty
+    for subject_usage_data in subject_formset_data:
+        if valid_metadata_usage(subject_usage_data):
+            # Populate object
+            subject_usage = ItemSubjectUsage(
+                subject=subject_usage_data["subject"],
+                type=subject_usage_data["type"],
+                item=item,
+            )
+            # Existing object with real id
+            if subject_usage_data["usage_id"] > 0:
+                subject_usage.id = subject_usage_data["usage_id"]
+            # Only delete if record already exists; otherwise, just don't save
+            if subject_usage_data["DELETE"]:
+                if subject_usage.id:
+                    subject_usage.delete()
+            else:
+                subject_usage.save()

--- a/oh_staff_ui/views_utils.py
+++ b/oh_staff_ui/views_utils.py
@@ -1,4 +1,12 @@
+import logging
 from django.db.models import Q
+from django.forms import formset_factory
+from django.http.request import HttpRequest  # for code completion
+from django.utils import timezone
+from oh_staff_ui.forms import ProjectItemForm, NameUsageForm
+from oh_staff_ui.models import ProjectItem, ItemNameUsage
+
+logger = logging.getLogger(__name__)
 
 
 def construct_keyword_query(query: str) -> Q:
@@ -15,3 +23,76 @@ def construct_keyword_query(query: str) -> Q:
         # OR the assembled set of words with the full query.
         full_q = full_q | words_q
     return full_q
+
+
+def get_all_item_data(item_id: int) -> dict:
+    item = ProjectItem.objects.get(pk=item_id)
+    names = ItemNameUsage.objects.filter(item=item_id).order_by("id")
+    return {
+        "item": item,
+        "names": names,
+    }
+
+
+def get_edit_item_context(item_id: int) -> dict:
+    NameUsageFormset = formset_factory(NameUsageForm, extra=1, can_delete=True)
+    # Populate forms with data from database
+    item_data = get_all_item_data(item_id)
+    logger.info(f"{item_data=}")
+    item = item_data["item"]
+    names = item_data["names"]
+    item_form = ProjectItemForm(
+        {"title": item.title, "type": item.type, "sequence": item.sequence}
+    )
+    # Formset needs list of dictionaries of initial values.
+    name_list = []
+    for name in names:
+        name_list.append(
+            {
+                "usage_id": name.id,
+                "type": name.type,
+                "name": name.name,
+            }
+        )
+    name_formset = NameUsageFormset(initial=name_list, prefix="names")
+    return {
+        "item": item,
+        "item_form": item_form,
+        "name_formset": name_formset,
+    }
+
+
+def save_all_item_data(item_id: int, request: HttpRequest) -> None:
+    NameUsageFormset = formset_factory(NameUsageForm, extra=1, can_delete=True)
+    item_form = ProjectItemForm(request.POST)
+    name_formset = NameUsageFormset(request.POST, prefix="names")
+
+    if item_form.is_valid() & name_formset.is_valid():
+        logger.info(f"Saving data for item {item_id}")
+        logger.info(item_form.cleaned_data)
+        logger.info(name_formset.cleaned_data)
+        # Item data
+        item = ProjectItem.objects.get(pk=item_id)
+        item.sequence = item_form.cleaned_data["sequence"]
+        item.title = item_form.cleaned_data["title"]
+        item.type = item_form.cleaned_data["type"]
+        item.last_modified_date = timezone.now()
+        item.last_modified_by = request.user
+        item.save()
+        # Name usage data
+        for name_usage_data in name_formset.cleaned_data:
+            # List of dictionaries, some/all of which can be empty
+            if name_usage_data:
+                name_usage = ItemNameUsage(
+                    name=name_usage_data["name"],
+                    type=name_usage_data["type"],
+                    item=item,
+                )
+                if name_usage_data["usage_id"] > 0:
+                    name_usage.id = name_usage_data["usage_id"]
+                if name_usage_data["DELETE"]:
+                    # Only delete if record already exists; otherwise, just don't save
+                    if name_usage.id:
+                        name_usage.delete()
+                else:
+                    name_usage.save()


### PR DESCRIPTION
Implements [SYS-1179](https://jira.library.ucla.edu/browse/SYS-1179).

This PR adds support for editing items and specific types of optional metadata (names and subjects, for now).  It establishes a basic "framework" for supporting other optional metadata:
* Define a "usage form" in `forms.py` which supports data for a "usage model".  For example, `NameUsageForm` supports the `ItemNameUsage` model.
  * Name & Subject forms use fully-controlled types and values backed by other models.
  * Some other forms will need to use controlled types, but uncontrolled values.
* Add code to `views_utils.py` which
  * Creates and populate a formset with existing values; see `get_name_formset()` and `get_subject_formset()`.
  * Adds the formset to `get_edit_item_context()`, so it can be passed to the `edit_item.html` template.
  * Saves the submitted data; see `save_item_names()` and `save_item_subjects()`.
  * Call the `save_xyz` methods from `save_all_item_data()`
 * The main view, `edit_item()` in `views.py`, should not need changing.  It passes the request to `save_all_item_data()`, builds a fresh context dictionary via `get_edit_item_context()` and passes that to the template.
 * The new `edit_item.html` template displays all relevant data and forms for adding/editing/deleting data.
   * Update the template to display each new formset in the appropriate place, following the current layout.
   * Since formset fields are being displayed individually, not via convenience templates like `form.as_p` or `form.as_div`, be sure to add each `formset.management_form` as well.

### Known limitations
* Only Name and Subject metadata is supported for now.  Other types will be added via separate tickets.
* New names & subjects must be added to items one at a time (though you can add one name and one subject at the same time), clicking the Save button.
  * Support for adding multiple names / subjects (and other types) at once will be added later, via javascript.
  * All names / subjects currently displayed can be edited and/or deleted now, with a single form submission.
* Some item metadata - Coverage, Status, and Parent - currently is not displayed and can't be edited.  This will be addressed later, via separate ticket.
* There's no "changes saved" confirmation message; I'm not currently sure how to add that, given the way the context is built and passed.

### Testing
* Load full sets of item and name data - not required, but helpful:
```
# Load full set of item data
$ docker-compose exec django python manage.py import_projectitems oh-projectitems-export-3.csv
# Load full set of name data
$ docker-compose exec django python manage.py import_names name-md-export.csv
# Other full sets of data, like subject, are not yet available.
```
* Retrieve existing item with name(s) associated.  Example: http://127.0.0.1:8000/search_results/ark/zz001bmsqw (which for me leads to http://127.0.0.1:8000/item/1234 , which has 2 names associated).
* Change type(s) - e.g., `interviewee` to `publisher` etc. - and name(s), by selecting different values from the drop down lists.
* Check the "Delete?" box to remove name associations (the "usage" records).
* Try combinations - adding a new type+name, changing existing type/name, deleting existing.  Combinations can be submitted together, subject to the limitation noted above of only adding one name at a time.
* Try subjects also, by themselves and in combination with names.
* Edit the item title / type / sequence.
* Report errors, if any... 
