### PR TITLE
SYS-1174: Add real and mock ARK support

### DIFF
--- a/.docker-compose_django.env
+++ b/.docker-compose_django.env
@@ -24,3 +24,6 @@ DJANGO_LOG_LEVEL=INFO
 DJANGO_SUPERUSER_USERNAME=admin
 DJANGO_SUPERUSER_PASSWORD=admin
 DJANGO_SUPERUSER_EMAIL=softwaredev-systems@library.ucla.edu
+
+# URL to ARK minter (PROD)
+DJANGO_ARK_MINTER=http://noid.library.ucla.edu/noidu_zz8+?mint+1

--- a/oh_staff_ui/templates/oh_staff_ui/add_item.html
+++ b/oh_staff_ui/templates/oh_staff_ui/add_item.html
@@ -1,6 +1,11 @@
 {% extends 'oh_staff_ui/base.html' %}
 
 {% block content %}
+
+{% for custom_error in custom_errors %}
+    <p>{{ custom_error }}</p>
+{% endfor %}
+
 <form name="add_item" id="add_item" method="POST">
     {% csrf_token %}
     <table>

--- a/project/settings.py
+++ b/project/settings.py
@@ -19,6 +19,9 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/4.1/howto/deployment/checklist/
 
+# Run-time environment, which controls some logic
+RUN_ENV = os.getenv("DJANGO_RUN_ENV")
+
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = os.getenv("DJANGO_SECRET_KEY")
 
@@ -182,3 +185,6 @@ LOGGING = {
 
 # Login
 LOGIN_REDIRECT_URL = "/"
+
+# ARK minter
+ARK_MINTER = os.getenv("DJANGO_ARK_MINTER")

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ Django == 4.1.3
 psycopg2 == 2.9.5
 gunicorn == 20.1.0
 whitenoise == 6.0.0
+requests == 2.28.2


### PR DESCRIPTION
Implements [SYS-1174](https://jira.library.ucla.edu/browse/SYS-1174).

This PR adds a `get_ark()` method to `views_utils.py`.  This method is called by the `add_item()` view.

If running in the `dev` environment, `get_ark()` returns a mock ARK, with prefix of `FAKE/` followed by 10 random(ish) hex characters, like `FAKE/249dd89b20`.  Otherwise, `get_ark()` tries to obtain a real ARK from our ARK minter service.  This can fail - the service may be unavailable, or forbidden due to IP address restrictions - in which case an `HTTPError` is thrown and logged:
```
CRITICAL 2023-03-16 20:11:28,881 oh_staff_ui.views_utils views_utils 403 Client Error: Forbidden for url: http://noid.library.ucla.edu/noidu_zz8+?mint+1
```
The `add_item()` view wraps the creation of a new item in a `try/except` block.  If it fails (currently, only checking for `HTTPError`), no item is created.  The user remains on the `add_item` page, with the same data they entered, so they can try again.

Failure screenshot:
![oh_ark_failure](https://user-images.githubusercontent.com/2213836/225804916-0cb85671-4800-4b18-8b62-63e2ea8d8f9f.png)
Success screenshot, with fake ARK:
![oh_ark_success](https://user-images.githubusercontent.com/2213836/225804949-414e3f00-2748-445d-b511-029d62d3453a.png)

Other notes:
* URL of the ARK minter service is set via environment variable, so code won't need to change if that service address changes.
* Fake ARKs are used only when running in `dev` environment, not `test` or `prod`.
* Exception handling probably could be improved.
* I should write test code for this, but didn't.

### Testing
* Changing the environment via `DJANGO_RUN_ENV` in `.docker-compose_django.env` requires restarting the application after each change.
* Quicker to change the test on line 34 of `views_utils.py`, which doesn't require application restart... just be sure to revert changes.

