### PR TITLE
SYS-1189: Add coverage, status and parent info to item editing screen

### DIFF
--- a/oh_staff_ui/forms.py
+++ b/oh_staff_ui/forms.py
@@ -1,10 +1,13 @@
 from django import forms
 from oh_staff_ui.models import (
+    ItemStatus,
     ItemType,
     Name,
     NameType,
     Subject,
     SubjectType,
+    get_default_status,
+    get_default_type,
 )
 
 
@@ -13,10 +16,20 @@ class ProjectItemForm(forms.Form):
         required=True, max_length=256, widget=forms.TextInput(attrs={"size": 80})
     )
     type = forms.ModelChoiceField(
-        required=True, queryset=ItemType.objects.all().order_by("type"), initial="Audio"
+        required=True,
+        queryset=ItemType.objects.all().order_by("type"),
+        initial=get_default_type,
     )
     sequence = forms.CharField(
         required=True, max_length=3, widget=forms.TextInput(attrs={"size": 3})
+    )
+    coverage = forms.CharField(
+        required=False, max_length=256, widget=forms.TextInput(attrs={"size": 80})
+    )
+    status = forms.ModelChoiceField(
+        required=True,
+        queryset=ItemStatus.objects.all().order_by("status"),
+        initial=get_default_status,
     )
 
 

--- a/oh_staff_ui/models.py
+++ b/oh_staff_ui/models.py
@@ -28,6 +28,12 @@ class ItemType(models.Model):
         return self.type
 
 
+def get_default_type():
+    # Provides default value for new ProjectItem type field.
+    # Caution: Must be updated if this literal value changes.
+    return ItemType.objects.get(type="Audio").id
+
+
 class ProjectItem(models.Model):
     ark = models.CharField(max_length=40, blank=False, null=False)
     coverage = models.CharField(max_length=256, blank=True, null=True)

--- a/oh_staff_ui/templates/oh_staff_ui/edit_item.html
+++ b/oh_staff_ui/templates/oh_staff_ui/edit_item.html
@@ -6,6 +6,13 @@
     <li>ARK: {{ item.ark }}</li>
     <li>created: {{ item.create_date }} by {{ item.created_by }}</li>
     <li>updated: {{ item.last_modified_date }} by {{ item.last_modified_by }}</li>
+    <li>Parent:
+        {% if item.parent %}
+        <a href="{% url 'edit_item' item.parent.id %}">{{ item.parent }}</a>
+        {% else %}
+        {{ item.parent }}
+        {% endif %}
+    </li>
 </ul>
 <form name="edit_item" id="edit_item" method="POST">
     {% csrf_token %}

--- a/oh_staff_ui/views_utils.py
+++ b/oh_staff_ui/views_utils.py
@@ -54,7 +54,13 @@ def get_edit_item_context(item_id: int) -> dict:
     item = ProjectItem.objects.get(pk=item_id)
     # item_form is "bound" with this data
     item_form = ProjectItemForm(
-        data={"title": item.title, "type": item.type, "sequence": item.sequence}
+        data={
+            "title": item.title,
+            "type": item.type,
+            "sequence": item.sequence,
+            "coverage": item.coverage,
+            "status": item.status,
+        }
     )
     name_formset = get_name_formset(item_id)
     subject_formset = get_subject_formset(item_id)
@@ -116,7 +122,9 @@ def save_all_item_data(item_id: int, request: HttpRequest) -> None:
         logger.info(f"SUBJECTS: {subject_formset.cleaned_data}")
         # Item data
         item = ProjectItem.objects.get(pk=item_id)
+        item.coverage = item_form.cleaned_data["coverage"]
         item.sequence = item_form.cleaned_data["sequence"]
+        item.status = item_form.cleaned_data["status"]
         item.title = item_form.cleaned_data["title"]
         item.type = item_form.cleaned_data["type"]
         item.last_modified_date = timezone.now()


### PR DESCRIPTION
Implements [SYS-1189](https://jira.library.ucla.edu/browse/SYS-1189).

This PR adds 3 fields to the `edit_item` template:
* coverage (free text, editable)
* status (controlled list, editable)
* parent (link, if parent exists, not editable)

A `get_default_status()` method was added to `models.py` to support the need for "In progress" to be the default status.  I also fixed the existing default type, so it now uses the `get_default_type()` method.

### Testing
* Load full set of project item data, if not already done:
`$ docker-compose exec django python manage.py import_projectitems oh-projectitems-export-3.csv`
* Do a search, like http://127.0.0.1:8000/search_results/title/allen
* View a few records. Interviews and legal agreements generally are children, so there should be a parent link.  Series are top-level and have no parent, so `None` should display.
* Edit coverage / status as desired  and confirm the changes persist when saved.
