### PR TITLE
SYS-1180: Display hierarchy on item edit pages

### DIFF
--- a/oh_staff_ui/templates/oh_staff_ui/edit_item.html
+++ b/oh_staff_ui/templates/oh_staff_ui/edit_item.html
@@ -14,6 +14,9 @@
         {% endif %}
     </li>
 </ul>
+<ul class="tree">
+    {% include "oh_staff_ui/item_tree.html" %}
+</ul>
 <form name="edit_item" id="edit_item" method="POST">
     {% csrf_token %}
     {{ item_form.as_div }}

--- a/oh_staff_ui/templates/oh_staff_ui/edit_item.html
+++ b/oh_staff_ui/templates/oh_staff_ui/edit_item.html
@@ -15,7 +15,12 @@
     </li>
 </ul>
 <ul class="tree">
-    {% include "oh_staff_ui/item_tree.html" %}
+    <li>
+        <details>
+            <summary>Hierarchy Context</summary>
+                <ul>{% include "oh_staff_ui/item_tree.html" %}</ul>
+        </details>
+    </li>
 </ul>
 <form name="edit_item" id="edit_item" method="POST">
     {% csrf_token %}

--- a/oh_staff_ui/templates/oh_staff_ui/edit_item.html
+++ b/oh_staff_ui/templates/oh_staff_ui/edit_item.html
@@ -15,12 +15,7 @@
     </li>
 </ul>
 <ul class="tree">
-    <li>
-        <details>
-            <summary>Hierarchy Context</summary>
-                <ul>{% include "oh_staff_ui/item_tree.html" %}</ul>
-        </details>
-    </li>
+    {% include "oh_staff_ui/item_tree.html" %}
 </ul>
 <form name="edit_item" id="edit_item" method="POST">
     {% csrf_token %}

--- a/oh_staff_ui/templates/oh_staff_ui/item_tree.html
+++ b/oh_staff_ui/templates/oh_staff_ui/item_tree.html
@@ -1,0 +1,50 @@
+{% for parent, children in relatives.items %}
+    {# if this is topmost parent or immediate parent of page we're on, open the details #}
+    {% if item in children or parent == top_parent %}
+        {% if children %}
+            <li>
+                <details open> 
+                    {# if this is the page we're on, don't link #}
+                    {% if parent == item %}
+                    <summary>{{parent}}</summary>
+                    {% else %}
+                    <summary><a href="{% url 'edit_item' parent.id %}">{{parent}} </a></summary>
+                    {% endif %}
+                    <ul>
+                        {% include "oh_staff_ui/item_tree.html" with relatives=children %}
+                    </ul>
+                </details>
+            </li>
+        {% else %}
+            {# if this is the page we're on, don't link #}
+            {% if parent == item %}
+                <li>{{parent}}</li>
+            {% else %}
+                <li><a href="{% url 'edit_item' parent.id %}">{{parent}}</a></li>
+            {% endif %}
+        {% endif %}
+    {% else %}
+        {% if children %}
+            <li>
+                <details> 
+                    {# if this is the page we're on, don't link #}
+                    {% if parent == item %}
+                    <summary>{{parent}}</summary>
+                    {% else %}
+                    <summary><a href="{% url 'edit_item' parent.id %}">{{parent}} </a></summary>
+                    {% endif %}
+                    <ul>
+                        {% include "oh_staff_ui/item_tree.html" with relatives=children %}
+                    </ul>
+                </details>
+            </li>
+        {% else %}
+            {# if this is the page we're on, don't link #}
+            {% if parent == item %}
+                <li>{{parent}}</li>
+            {% else %}
+                <li><a href="{% url 'edit_item' parent.id %}">{{parent}}</a></li>
+            {% endif %}
+        {% endif %}
+    {% endif %}
+{% endfor %}

--- a/oh_staff_ui/templates/oh_staff_ui/item_tree.html
+++ b/oh_staff_ui/templates/oh_staff_ui/item_tree.html
@@ -1,50 +1,25 @@
 {% for parent, children in relatives.items %}
     {# if this is topmost parent or immediate parent of page we're on, open the details #}
-    {% if item in children or parent == top_parent %}
-        {% if children %}
-            <li>
-                <details open> 
-                    {# if this is the page we're on, don't link #}
-                    {% if parent == item %}
-                    <summary>{{parent}}</summary>
-                    {% else %}
-                    <summary><a href="{% url 'edit_item' parent.id %}">{{parent}} </a></summary>
-                    {% endif %}
-                    <ul>
-                        {% include "oh_staff_ui/item_tree.html" with relatives=children %}
-                    </ul>
-                </details>
-            </li>
-        {% else %}
-            {# if this is the page we're on, don't link #}
-            {% if parent == item %}
-                <li>{{parent}}</li>
-            {% else %}
-                <li><a href="{% url 'edit_item' parent.id %}">{{parent}}</a></li>
-            {% endif %}
-        {% endif %}
+    {% if children %}
+        <li>
+            <details {% if item in children or parent == top_parent %}open{% endif %}> 
+                {# if this is the page we're on, don't link #}
+                {% if parent == item %}
+                <summary>{{parent}}</summary>
+                {% else %}
+                <summary><a href="{% url 'edit_item' parent.id %}">{{parent}} </a></summary>
+                {% endif %}
+                <ul>
+                    {% include "oh_staff_ui/item_tree.html" with relatives=children %}
+                </ul>
+            </details>
+        </li>
     {% else %}
-        {% if children %}
-            <li>
-                <details> 
-                    {# if this is the page we're on, don't link #}
-                    {% if parent == item %}
-                    <summary>{{parent}}</summary>
-                    {% else %}
-                    <summary><a href="{% url 'edit_item' parent.id %}">{{parent}} </a></summary>
-                    {% endif %}
-                    <ul>
-                        {% include "oh_staff_ui/item_tree.html" with relatives=children %}
-                    </ul>
-                </details>
-            </li>
+        {# if this is the page we're on, don't link #}
+        {% if parent == item %}
+            <li>{{parent}}</li>
         {% else %}
-            {# if this is the page we're on, don't link #}
-            {% if parent == item %}
-                <li>{{parent}}</li>
-            {% else %}
-                <li><a href="{% url 'edit_item' parent.id %}">{{parent}}</a></li>
-            {% endif %}
+            <li><a href="{% url 'edit_item' parent.id %}">{{parent}}</a></li>
         {% endif %}
     {% endif %}
 {% endfor %}

--- a/oh_staff_ui/templates/oh_staff_ui/item_tree.html
+++ b/oh_staff_ui/templates/oh_staff_ui/item_tree.html
@@ -1,25 +1,38 @@
-{% for parent, children in relatives.items %}
-    {# if this is topmost parent or immediate parent of page we're on, open the details #}
-    {% if children %}
-        <li>
-            <details {% if item in children or parent == top_parent %}open{% endif %}> 
-                {# if this is the page we're on, don't link #}
-                {% if parent == item %}
-                <summary>{{parent}}</summary>
-                {% else %}
-                <summary><a href="{% url 'edit_item' parent.id %}">{{parent}} </a></summary>
-                {% endif %}
-                <ul>
-                    {% include "oh_staff_ui/item_tree.html" with relatives=children %}
-                </ul>
-            </details>
-        </li>
-    {% else %}
-        {# if this is the page we're on, don't link #}
-        {% if parent == item %}
-            <li>{{parent}}</li>
-        {% else %}
-            <li><a href="{% url 'edit_item' parent.id %}">{{parent}}</a></li>
-        {% endif %}
-    {% endif %}
+{% for series, interviews in relatives.items %}
+    <li>
+        <details open>
+            {% if series == item %}
+            <summary class="current-item">{{series}}</summary>
+            {% else %}
+            <summary><a href="{% url 'edit_item' series.id %}">{{series}}</a></summary>
+            {% endif %}
+            <ul>
+                {% for interview, files in interviews.items %}
+                <li>
+                    <details
+                        {% if interview == item or item in files %}
+                            open>
+                        {% else %}
+                            >
+                        {% endif %}
+                        {% if interview == item %}
+                            <summary class="current-item">{{interview}}</summary>
+                        {% else %}
+                            <summary><a href="{% url 'edit_item' interview.id %}">{{interview}}</a></summary>
+                        {% endif %}
+                        <ul>
+                            {% for file in files %}
+                                {% if file == item %}
+                                    <li class="current-item">{{file}}</li>
+                                {% else %}
+                                    <li><a href="{% url 'edit_item' file.id %}">{{file}}</a></li>
+                                {% endif %}
+                            {% endfor %}
+                        </ul>
+                    </details>
+                </li>
+                {% endfor %}
+            </ul>
+        </details>
+    </li>
 {% endfor %}

--- a/oh_staff_ui/templates/oh_staff_ui/item_tree.html
+++ b/oh_staff_ui/templates/oh_staff_ui/item_tree.html
@@ -1,6 +1,7 @@
 {% for series, interviews in relatives.items %}
+    {% if interviews %}
     <li>
-        <details open>
+        <details>
             {% if series == item %}
             <summary class="current-item">{{series}}</summary>
             {% else %}
@@ -8,31 +9,46 @@
             {% endif %}
             <ul>
                 {% for interview, files in interviews.items %}
-                <li>
-                    <details
-                        {% if interview == item or item in files %}
-                            open>
-                        {% else %}
-                            >
-                        {% endif %}
+                {% if files %}
+                    <li>
+                        <details
+                            {% if interview == item or item in files %}
+                                open>
+                            {% else %}
+                                >
+                            {% endif %}
+                            {% if interview == item %}
+                                <summary class="current-item">{{interview}}</summary>
+                            {% else %}
+                                <summary><a href="{% url 'edit_item' interview.id %}">{{interview}}</a></summary>
+                            {% endif %}
+                            <ul>
+                                {% for file in files %}
+                                    {% if file == item %}
+                                        <li class="current-item">{{file}}</li>
+                                    {% else %}
+                                        <li><a href="{% url 'edit_item' file.id %}">{{file}}</a></li>
+                                    {% endif %}
+                                {% endfor %}
+                            </ul>
+                        </details>
+                    </li>
+                    {% else %}
                         {% if interview == item %}
-                            <summary class="current-item">{{interview}}</summary>
+                            <li class="current-item">{{interview}}</li>
                         {% else %}
-                            <summary><a href="{% url 'edit_item' interview.id %}">{{interview}}</a></summary>
+                            <li><a href="{% url 'edit_item' interview.id %}">{{interview}}</a></li>
                         {% endif %}
-                        <ul>
-                            {% for file in files %}
-                                {% if file == item %}
-                                    <li class="current-item">{{file}}</li>
-                                {% else %}
-                                    <li><a href="{% url 'edit_item' file.id %}">{{file}}</a></li>
-                                {% endif %}
-                            {% endfor %}
-                        </ul>
-                    </details>
-                </li>
+                {% endif %}
                 {% endfor %}
             </ul>
         </details>
     </li>
+    {% else %}
+        {% if series == item %}
+            <li class="current-item">{{series}}</li>
+        {% else %}
+            <li><a href="{% url 'edit_item' series.id %}">{{series}}</a></li>
+        {% endif %}
+    {% endif %}
 {% endfor %}

--- a/oh_staff_ui/views_utils.py
+++ b/oh_staff_ui/views_utils.py
@@ -423,7 +423,7 @@ def get_top_parent(item: ProjectItem) -> ProjectItem:
 
 def get_descendants(item: ProjectItem) -> dict:
     descendants = {}
-    children = ProjectItem.objects.filter(parent=item).order_by("title")
+    children = ProjectItem.objects.filter(parent=item).order_by("sequence", "title")
     if not children:
         descendants = None
     else:

--- a/oh_staff_ui/views_utils.py
+++ b/oh_staff_ui/views_utils.py
@@ -84,6 +84,9 @@ def get_edit_item_context(item_id: int) -> dict:
     copyright_formset = get_copyright_formset(item_id)
     language_formset = get_language_formset(item_id)
     resource_formset = get_resource_formset(item_id)
+    top_parent = get_top_parent(item)
+    partial_relatives = get_descendants(top_parent)
+    relatives = {top_parent: partial_relatives}
     return {
         "item": item,
         "item_form": item_form,
@@ -93,6 +96,8 @@ def get_edit_item_context(item_id: int) -> dict:
         "publisher_formset": publisher_formset,
         "resource_formset": resource_formset,
         "subject_formset": subject_formset,
+        "relatives": relatives,
+        "top_parent": top_parent,
     }
 
 
@@ -410,3 +415,21 @@ def save_item_subjects(item: ProjectItem, subject_formset_data: list) -> None:
                     subject_usage.delete()
             else:
                 subject_usage.save()
+
+
+def get_top_parent(item: ProjectItem) -> ProjectItem:
+    current_parent = item
+    while current_parent.parent:
+        current_parent = current_parent.parent
+    return current_parent
+
+
+def get_descendants(item: ProjectItem) -> dict:
+    descendants = {}
+    children = ProjectItem.objects.filter(parent=item)
+    if not children:
+        descendants = None
+    else:
+        for child in children:
+            descendants[child] = get_descendants(child)
+    return descendants

--- a/oh_staff_ui/views_utils.py
+++ b/oh_staff_ui/views_utils.py
@@ -423,7 +423,7 @@ def get_top_parent(item: ProjectItem) -> ProjectItem:
 
 def get_descendants(item: ProjectItem) -> dict:
     descendants = {}
-    children = ProjectItem.objects.filter(parent=item)
+    children = ProjectItem.objects.filter(parent=item).order_by("title")
     if not children:
         descendants = None
     else:

--- a/oh_staff_ui/views_utils.py
+++ b/oh_staff_ui/views_utils.py
@@ -84,9 +84,7 @@ def get_edit_item_context(item_id: int) -> dict:
     copyright_formset = get_copyright_formset(item_id)
     language_formset = get_language_formset(item_id)
     resource_formset = get_resource_formset(item_id)
-    top_parent = get_top_parent(item)
-    partial_relatives = get_descendants(top_parent)
-    relatives = {top_parent: partial_relatives}
+    relatives = get_relatives(item)
     return {
         "item": item,
         "item_form": item_form,
@@ -97,7 +95,6 @@ def get_edit_item_context(item_id: int) -> dict:
         "resource_formset": resource_formset,
         "subject_formset": subject_formset,
         "relatives": relatives,
-        "top_parent": top_parent,
     }
 
 
@@ -433,3 +430,10 @@ def get_descendants(item: ProjectItem) -> dict:
         for child in children:
             descendants[child] = get_descendants(child)
     return descendants
+
+
+def get_relatives(item: ProjectItem) -> dict:
+    top_parent = get_top_parent(item)
+    partial_relatives = get_descendants(top_parent)
+    relatives = {top_parent: partial_relatives}
+    return relatives

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -5,3 +5,7 @@
 .search-results td {
     border: 1px solid;
 }
+
+.current-item {
+    font-weight: bold;
+}


### PR DESCRIPTION
Implements [SYS-1180](https://jira.library.ucla.edu/browse/SYS-1180)

This PR adds a "local hierarchy" display to item edit pages. This hierarchy is presented in a collapsible tree up to the Series level. Users can expand and collapse the tree and use links to navigate to related items.

I've set this as a draft PR for now since I have a few concerns about my solution:
* The recursive item_tree template may be overcomplicated and difficult to maintain.
* We could probably use more styling to highlight what page we're currently on in the hierarchy.
* I'm not sure how far the tree should be "open" by default. Currently, the Series is always expanded, as is the immediate parent of the current item. "Interview" level items are not expanded by default, but displayed alongside siblings.
    * This implementation is also not designed for more than 3 hierarchy levels (series, interview, file) - not sure how flexible we need to be in general.

Screenshots:
Series level
<img width="359" alt="image" src="https://user-images.githubusercontent.com/7283991/227065936-502fd898-13be-414c-a702-605af8a88208.png">
Interview level
<img width="359" alt="image" src="https://user-images.githubusercontent.com/7283991/227066010-7adce047-5086-423f-a62b-c2f193451c4e.png">
File level
<img width="359" alt="image" src="https://user-images.githubusercontent.com/7283991/227066040-3041185d-e669-467e-8399-52ee0bffe646.png">
