### PR TITLE
SYS-1199: Add script to reset local development database

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,25 @@ The container runs via `docker_scripts/entrypoint.sh`, which
 
    ```$ docker-compose down```
 
+### Resetting the local database
+
+The local docker-based development database can be reset as needed.  This is helpful when switching between branches which involve migrations, or when testing data loading and transformation.
+
+To do this, run:
+`docker_scripts/nuke_dev_db.sh`
+
+It does the following:
+* Shuts down the application
+* Drops the docker volume for the database
+* Starts the application
+* Reloads data files via management commands.
+  * This currently is just `ProjectItem` and `Name` files; others will be added as loaders are finished.
+
+The script warns users, and requires them to confirm their decision.
+
+Developers can opt out of reloading data by adding a specific parameter:
+`docker_scripts/nuke_dev_db.sh NOLOAD`
+
 ### Logging
 
 Basic logging is available, with logs captured in `logs/application.log`.  At present, logs from both the custom application code and Django itself are captured.

--- a/docker_scripts/nuke_dev_db.sh
+++ b/docker_scripts/nuke_dev_db.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# Removes local docker-based development database for the Oral History staff UI application.
+# The database is recreated automatically when docker-compose starts the application.
+# nuke_dev_db.sh
+
+# Optionally, loads full data files to repopulate the database, which can take a few minutes.
+# Opt out of reloading by adding NOLOAD as the only parameter:
+# nuke_dev_db.sh NOLOAD
+
+echo "*** WARNING: THIS WILL COMPLETELY DESTROY YOUR CURRENT DEV DATABASE! ***"
+echo ""
+echo "Are you SURE you want to do this?  Choose 1) to continue, anything else to exit."
+select yn in "YES" "NO, EXIT!"; do
+  case $yn in 
+    YES ) break;;
+    * ) echo "Cancelled - exiting"; exit;;
+  esac
+done
+
+# Capture parameter, if any.
+# If no parameter, data will be reloaded.
+if [ -z "$1" ]; then
+  RELOAD=Y
+else
+  if [ "$1" = "NOLOAD" ]; then
+    RELOAD=N
+  else
+    RELOAD=Y
+  fi
+fi
+
+echo "Shutting down local docker-compose system..."
+docker-compose down
+sleep 5
+
+echo "Removing local docker database volume..."
+docker volume rm oral-history-staff-ui_pg_data
+
+echo "Starting local docker-compose system in background..."
+docker-compose up -d
+sleep 5
+
+# Currently, only support reloading all data; may be more specific later.
+if [ "${RELOAD}" = "Y" ]; then
+  echo "=================================="
+  echo "Reloading all data, please wait..."
+  docker-compose exec django python manage.py import_projectitems oh-projectitems-export-3.csv
+  docker-compose exec django python manage.py import_names name-md-export.csv
+fi
+
+echo "All done.  Check container logs by running:"
+echo "    docker-compose logs django"


### PR DESCRIPTION
Implements [SYS-1199](https://jira.library.ucla.edu/browse/SYS-1199).

This PR adds a simple shell script, `docker_scripts/nuke_dev_db.sh`, which can be run to reset the local docker-based development database.  It does the following:
* Shuts down the application
* Drops the docker volume for the database
* Starts the application
* Reloads data files via management commands.
  * This currently is just `ProjectItem` and `Name` files; others will be added as loaders are finished.
 
Developers can opt out of reloading data by adding a specific parameter:
`docker_scripts/nuke_dev_db.sh NOLOAD`

`README.md` is updated with this information.
