### PR TITLE
SYS-1200: Initial version of Helm chart

### DIFF
--- a/.docker-compose_db.env
+++ b/.docker-compose_db.env
@@ -16,7 +16,8 @@ DJANGO_DB_NAME=oral_history
 DJANGO_DB_USER=oral_history
 DJANGO_DB_PASSWORD=fake_oh_pass
 
-# PostgreSQL container requires specific variable names
+# PostgreSQL container requires specific variable names.
+# These are local only, not needed for deployment or in Helm chart files.
 POSTGRES_DB=${DJANGO_DB_NAME}
 POSTGRES_USER=${DJANGO_DB_USER}
 POSTGRES_PASSWORD=${DJANGO_DB_PASSWORD}

--- a/.docker-compose_django.env
+++ b/.docker-compose_django.env
@@ -15,7 +15,7 @@ DJANGO_ALLOWED_HOSTS=localhost,127.0.0.1,[::1]
 
 # Django 4 may require this, at least in our deployment environment.
 # Comma separated list (if multiple) of additional trusted hosts
-DJANGO_CSRF_TRUSTED_ORIGINS=https://oh-staff-ui.library.ucla.edu
+DJANGO_CSRF_TRUSTED_ORIGINS=https://oh-staff.library.ucla.edu
 
 # DEBUG, INFO, WARNING, ERROR, CRITICAL
 DJANGO_LOG_LEVEL=INFO
@@ -27,3 +27,29 @@ DJANGO_SUPERUSER_EMAIL=softwaredev-systems@library.ucla.edu
 
 # URL to ARK minter (PROD)
 DJANGO_ARK_MINTER=http://noid.library.ucla.edu/noidu_zz8+?mint+1
+
+# Directory containing files "uploaded" by staff.
+# Relative path, starting top level of Django project
+DJANGO_OH_FILE_SOURCE=samples
+# Or absolute path, if preferred
+#DJANGO_OH_FILE_SOURCE=/home/django/oral-history-staff-ui/samples
+
+# Use "test" directories?  Was based on DJANGO_RUN_ENV but can't use that
+# when in production on test k8s environment.
+# Use "Yes" and "No" here.
+DJANGO_USE_TEST_DIRS=No
+
+# Various media directories for processed files
+# Relative paths for development, absolute for real mounts
+# Oral History source files
+DJANGO_OH_LIBPARTNERS=media_dev/oh_source
+#DJANGO_OH_LIBPARTNERS=/media/oh_source
+# Masters "shadow landing zone"
+DJANGO_OH_MASTERSLZ=media_dev/oh_lz
+#DJANGO_OH_MASTERSLZ=/media/oh_lz
+# Wowza
+DJANGO_OH_WOWZA=media_dev/oh_wowza
+#DJANGO_OH_WOWZA=/media/oh_wowza
+# Static files
+DJANGO_OH_STATIC=media_dev/oh_static
+#DJANGO_OH_STATIC=/media/oh_static

--- a/.github/workflows/push_helm_chart.yml
+++ b/.github/workflows/push_helm_chart.yml
@@ -1,0 +1,37 @@
+---
+
+name: Push Helm Chart to ChartMuseum
+on: 
+  push:
+    paths:
+      - 'charts/**'
+      - '!charts/*-*-values.yaml'
+    branches:
+      - main
+
+jobs:
+  push_helm_chart:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code repo 
+        uses: actions/checkout@v3
+
+      - name: Install Helm 
+        uses: azure/setup-helm@v2.0
+        with:
+          version: 'latest'
+
+      - name: Install Helm ChartMuseum plugin
+        run: |
+          helm plugin install https://github.com/chartmuseum/helm-push
+      
+      - name: Add ChartMuseum repo 
+        run: |
+          helm repo add uclalibcm https://chartmuseum.library.ucla.edu
+      
+      - name: Push Helm Chart to ChartMuseum repo
+        env: 
+          HELM_REPO_USERNAME: ${{ secrets.CM_BASICAUTH_USERNAME }}
+          HELM_REPO_PASSWORD: ${{ secrets.CM_BASICAUTH_PASSWORD }}
+        run: |
+          helm cm-push charts/ uclalibcm

--- a/charts/.helmignore
+++ b/charts/.helmignore
@@ -1,0 +1,27 @@
+# Helm Ignore
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/
+# Environment-specific Values files
+/test-ohstaff-values.yaml
+/prod-ohstaff-values.yaml

--- a/charts/Chart.yaml
+++ b/charts/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+appVersion: "0.1"
+description: Chart for Oral History Staff UI
+name: oh-staff
+version: 0.0.1

--- a/charts/Chart.yaml
+++ b/charts/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: "0.1"
 description: Chart for Oral History Staff UI
 name: oh-staff
-version: 0.0.1
+version: 0.0.2

--- a/charts/prod-ohstaff-values.yaml
+++ b/charts/prod-ohstaff-values.yaml
@@ -1,0 +1,116 @@
+# Values for oh-staff.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: uclalibrary/oral-history-staff-ui
+  tag: v0.0.1
+  pullPolicy: Always
+
+nameOverride: ""
+
+fullnameOverride: ""
+
+service:
+  type: NodePort
+  port: 80
+
+ingress:
+  enabled: "true"
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "600"
+    cert-manager.io/cluster-issuer: sectigo-acme-clusterissuer
+    kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: 'oh-staff.library.ucla.edu'
+      paths:
+        - "/"
+  tls:
+  - secretName: oh-staff-tls
+    hosts:
+      - oh-staff.library.ucla.edu
+
+django:
+  env:
+    run_env: "prod"
+    debug: "false"
+    # DEBUG, INFO, WARNING, ERROR, CRITICAL
+    log_level: "INFO"
+    allowed_hosts:
+      - oh-staff.library.ucla.edu
+    csrf_trusted_origins:
+      - https://oh-staff.library.ucla.edu
+    ark_minter: "http://noid.library.ucla.edu/noidu_zz8+?mint+1"
+    # Now pointing to production db
+    db_backend: "django.db.backends.postgresql_psycopg2"
+    db_host: "p-d-postgres.library.ucla.edu"
+    db_port: 5432
+    db_name: "oral_history_staff"
+    db_user: "oral_history_staff"
+    # Specific directory used for source files
+    oh_file_source: "/media/oh_source/upload"
+    oh_libpartners: "/media/oh_source"
+    oh_masterslz: "/media/oh_lz"
+    oh_static: "/media/oh_static"
+    oh_wowza: "/media/oh_wowza"
+    # "Yes" or "No"
+    use_test_dirs: "No"
+
+  externalSecrets:
+    enabled: "true"
+    env:
+      # Application database used by django
+      db_password: "/systems/prodsoftwaredev/oh-staff/db_password"
+      django_secret_key: "/systems/prodsoftwaredev/oh-staff/django_secret_key"
+
+# PersistentVolume and PersistentVolumeClaim parameters
+persistentVolumes:
+  ohsource:
+    storage: "5.5Ti"
+    access: "ReadOnlyMany"
+    server: "lib-partners.in.library.ucla.edu"
+    path: "/OralHistory"
+  ohmasters:
+    storage: "1.1Ti"
+    access: "ReadWriteMany"
+    server: "dlp.in.library.ucla.edu"
+    path: "/oralhistory_LZ"
+  ohwowza:
+    storage: "5Ti"
+    access: "ReadWriteMany"
+    server: "wowza.in.library.ucla.edu"
+    path: "/dlp/oralhistory"
+  ohstatic:
+    storage: "300Gi"
+    access: "ReadWriteMany"
+    server: "dlp.in.library.ucla.edu"
+    path: "/oralhistory"
+
+# Volume mount specification for the container
+volumeMounts:
+  - name: "ohsource"
+    mountPath: "/media/oh_source"
+  - name: "ohmasters"
+    mountPath: "/media/oh_lz"
+  - name: "ohwowza"
+    mountPath: "/media/oh_wowza/"
+  - name: "ohstatic"
+    mountPath: "/media/oh_static"
+
+resources:
+  limits:
+    cpu: 1000m
+    memory: 4Gi
+  requests:
+    cpu: 250m
+    memory: 100Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/charts/prod-ohstaff-values.yaml
+++ b/charts/prod-ohstaff-values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: uclalibrary/oral-history-staff-ui
-  tag: v0.0.1
+  tag: v0.0.2
   pullPolicy: Always
 
 nameOverride: ""
@@ -77,17 +77,17 @@ persistentVolumes:
     storage: "1.1Ti"
     access: "ReadWriteMany"
     server: "dlp.in.library.ucla.edu"
-    path: "/oralhistory_LZ"
+    path: "/oralhistory_LZ/test_oh_staff_ui"
   ohwowza:
     storage: "5Ti"
     access: "ReadWriteMany"
     server: "wowza.in.library.ucla.edu"
-    path: "/dlp/oralhistory"
+    path: "/dlp/oralhistory/test_oh_staff_ui"
   ohstatic:
     storage: "300Gi"
     access: "ReadWriteMany"
     server: "dlp.in.library.ucla.edu"
-    path: "/oralhistory"
+    path: "/oralhistory/test_oh_staff_ui"
 
 # Volume mount specification for the container
 volumeMounts:

--- a/charts/prod-ohstaff-values.yaml
+++ b/charts/prod-ohstaff-values.yaml
@@ -14,8 +14,7 @@ nameOverride: ""
 fullnameOverride: ""
 
 service:
-  type: NodePort
-  port: 80
+  type: ClusterIP
 
 ingress:
   enabled: "true"

--- a/charts/templates/NOTES.txt
+++ b/charts/templates/NOTES.txt
@@ -1,0 +1,22 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ . }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "oh-staff.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "oh-staff.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "oh-staff.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "oh-staff.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}

--- a/charts/templates/_helpers.tpl
+++ b/charts/templates/_helpers.tpl
@@ -1,0 +1,69 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "oh-staff.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "oh-staff.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "oh-staff.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "oh-staff.labels" -}}
+helm.sh/chart: {{ include "oh-staff.chart" . }}
+{{ include "oh-staff.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "oh-staff.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "oh-staff.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Deployment Volume Configuration
+*/}}
+{{- define "oh-staff.volumes" -}}
+- name: "ohsource"
+  persistentVolumeClaim:
+    claimName: {{ include "oh-staff.fullname" . }}-pvc-ohsource
+- name: "ohmasters"
+  persistentVolumeClaim:
+    claimName: {{ include "oh-staff.fullname" . }}-pvc-ohmasters
+- name: "ohwowza"
+  persistentVolumeClaim:
+    claimName: {{ include "oh-staff.fullname" . }}-pvc-ohwowza
+- name: "ohstatic"
+  persistentVolumeClaim:
+    claimName: {{ include "oh-staff.fullname" . }}-pvc-ohstatic
+{{- end }}

--- a/charts/templates/configmap.yaml
+++ b/charts/templates/configmap.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "oh-staff.fullname" . }}-configmap
+  namespace: oh-staff{{ .Values.django.env.run_env }}
+  labels:
+    {{- include "oh-staff.labels" . | nindent 4 }}
+data:
+  DJANGO_RUN_ENV: {{ .Values.django.env.run_env }}
+  DJANGO_DEBUG: {{ .Values.django.env.debug | quote }}
+  DJANGO_LOG_LEVEL: {{ .Values.django.env.log_level }}
+  DJANGO_ALLOWED_HOSTS: {{ range .Values.django.env.allowed_hosts }}{{ . | quote }}{{ end }}
+  DJANGO_CSRF_TRUSTED_ORIGINS: {{ range .Values.django.env.csrf_trusted_origins }}{{ . | quote }}{{ end }}
+  DJANGO_ARK_MINTER: {{ .Values.django.env.ark_minter }}
+  DJANGO_DB_BACKEND: {{ .Values.django.env.db_backend }}
+  DJANGO_DB_HOST: {{ .Values.django.env.db_host }}
+  DJANGO_DB_PORT: {{ .Values.django.env.db_port | quote }}
+  DJANGO_DB_NAME: {{ .Values.django.env.db_name }}
+  DJANGO_DB_USER: {{ .Values.django.env.db_user }}
+  DJANGO_OH_FILE_SOURCE: {{ .Values.django.env.oh_file_source }}
+  DJANGO_OH_LIBPARTNERS: {{ .Values.django.env.oh_libpartners }}
+  DJANGO_OH_MASTERSLZ: {{ .Values.django.env.oh_masterslz }}
+  DJANGO_OH_STATIC: {{ .Values.django.env.oh_static }}
+  DJANGO_OH_WOWZA: {{ .Values.django.env.oh_wowza }}
+  DJANGO_USE_TEST_DIRS: {{ .Values.django.env.use_test_dirs | quote }}

--- a/charts/templates/deployment.yaml
+++ b/charts/templates/deployment.yaml
@@ -1,0 +1,66 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "oh-staff.fullname" . }}
+  namespace: oh-staff{{ .Values.django.env.run_env }}
+  labels:
+    {{- include "oh-staff.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "oh-staff.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "oh-staff.selectorLabels" . | nindent 8 }}
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "oh-staff.fullname" . }}-configmap
+            - secretRef:
+                name: {{ include "oh-staff.fullname" . }}-secrets
+          ports:
+            - name: http
+              containerPort: 8000
+              protocol: TCP
+          volumeMounts:
+            {{- toYaml .Values.volumeMounts | nindent 12 }}
+          livenessProbe:
+            httpGet:
+              path: /upload_file
+              port: http
+              httpHeaders:
+                - name: Host
+                  value: {{ range .Values.django.env.allowed_hosts }}{{ . }}{{ end }}
+            initialDelaySeconds: 10
+            timeoutSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /upload_file
+              port: http
+              httpHeaders:
+                - name: Host
+                  value: {{ range .Values.django.env.allowed_hosts }}{{ . }}{{ end }}
+            initialDelaySeconds: 10
+            timeoutSeconds: 10
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      volumes:
+        {{- include "oh-staff.volumes" . | nindent 8 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/templates/deployment.yaml
+++ b/charts/templates/deployment.yaml
@@ -32,7 +32,7 @@ spec:
             {{- toYaml .Values.volumeMounts | nindent 12 }}
           livenessProbe:
             httpGet:
-              path: /upload_file
+              path: /item_search/
               port: http
               httpHeaders:
                 - name: Host
@@ -41,7 +41,7 @@ spec:
             timeoutSeconds: 10
           readinessProbe:
             httpGet:
-              path: /upload_file
+              path: /item_search/
               port: http
               httpHeaders:
                 - name: Host

--- a/charts/templates/externalsecret.yaml
+++ b/charts/templates/externalsecret.yaml
@@ -1,0 +1,22 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: {{ include "oh-staff.fullname" . }}-externalsecret
+  namespace: oh-staff{{ .Values.django.env.run_env }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation
+spec:
+  refreshInterval: 10m
+  secretStoreRef:
+    name: systems-clustersecretstore
+    kind: ClusterSecretStore
+  target:
+    name: {{ include "oh-staff.fullname" . }}-secrets
+  data:
+    - secretKey: "DJANGO_SECRET_KEY"
+      remoteRef:
+        key: {{ .Values.django.externalSecrets.env.django_secret_key }}
+    - secretKey: "DJANGO_DB_PASSWORD"
+      remoteRef:
+        key: {{ .Values.django.externalSecrets.env.db_password }}

--- a/charts/templates/ingress.yaml
+++ b/charts/templates/ingress.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "oh-staff.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  namespace: oh-staff{{ .Values.django.env.run_env }}
+  labels:
+    {{- include "oh-staff.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ . | quote }}
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+          {{- end }}
+     {{- end }}
+{{- end }}

--- a/charts/templates/namespace.yaml
+++ b/charts/templates/namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: oh-staff{{ .Values.django.env.run_env }}
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-delete-policy": hook-failed

--- a/charts/templates/pv-ohmasters.yaml
+++ b/charts/templates/pv-ohmasters.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: {{ include "oh-staff.fullname" . }}-pv-ohmasters
+spec:
+  capacity:
+    storage: {{ .Values.persistentVolumes.ohmasters.storage | quote }}
+  accessModes:
+    - {{ .Values.persistentVolumes.ohmasters.access }}
+  nfs:
+    server: {{ .Values.persistentVolumes.ohmasters.server | quote }}
+    path: {{ .Values.persistentVolumes.ohmasters.path | quote }}
+  mountOptions:
+    - nfsvers=3

--- a/charts/templates/pv-ohsource.yaml
+++ b/charts/templates/pv-ohsource.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: {{ include "oh-staff.fullname" . }}-pv-ohsource
+spec:
+  capacity:
+    storage: {{ .Values.persistentVolumes.ohsource.storage | quote }}
+  accessModes:
+    - {{ .Values.persistentVolumes.ohsource.access }}
+  nfs:
+    server: {{ .Values.persistentVolumes.ohsource.server | quote }}
+    path: {{ .Values.persistentVolumes.ohsource.path | quote }}
+  mountOptions:
+    - nfsvers=3

--- a/charts/templates/pv-ohstatic.yaml
+++ b/charts/templates/pv-ohstatic.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: {{ include "oh-staff.fullname" . }}-pv-ohstatic
+spec:
+  capacity:
+    storage: {{ .Values.persistentVolumes.ohstatic.storage | quote }}
+  accessModes:
+    - {{ .Values.persistentVolumes.ohstatic.access }}
+  nfs:
+    server: {{ .Values.persistentVolumes.ohstatic.server | quote }}
+    path: {{ .Values.persistentVolumes.ohstatic.path | quote }}
+  mountOptions:
+    - nfsvers=3

--- a/charts/templates/pv-ohwowza.yaml
+++ b/charts/templates/pv-ohwowza.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: {{ include "oh-staff.fullname" . }}-pv-ohwowza
+spec:
+  capacity:
+    storage: {{ .Values.persistentVolumes.ohwowza.storage | quote }}
+  accessModes:
+    - {{ .Values.persistentVolumes.ohwowza.access }}
+  nfs:
+    server: {{ .Values.persistentVolumes.ohwowza.server | quote }}
+    path: {{ .Values.persistentVolumes.ohwowza.path | quote }}
+  mountOptions:
+    - nfsvers=3

--- a/charts/templates/pvc-ohmasters.yaml
+++ b/charts/templates/pvc-ohmasters.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "oh-staff.fullname" . }}-pvc-ohmasters
+  namespace: oh-staff{{ .Values.django.env.run_env }}
+spec:
+  accessModes:
+    - {{ .Values.persistentVolumes.ohmasters.access }}
+  storageClassName: ""
+  resources:
+    requests:
+      storage: {{ .Values.persistentVolumes.ohmasters.storage }}
+  volumeName: {{ include "oh-staff.fullname" . }}-pv-ohmasters

--- a/charts/templates/pvc-ohsource.yaml
+++ b/charts/templates/pvc-ohsource.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "oh-staff.fullname" . }}-pvc-ohsource
+  namespace: oh-staff{{ .Values.django.env.run_env }}
+spec:
+  accessModes:
+    - {{ .Values.persistentVolumes.ohsource.access }}
+  storageClassName: ""
+  resources:
+    requests:
+      storage: {{ .Values.persistentVolumes.ohsource.storage }}
+  volumeName: {{ include "oh-staff.fullname" . }}-pv-ohsource

--- a/charts/templates/pvc-ohstatic.yaml
+++ b/charts/templates/pvc-ohstatic.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "oh-staff.fullname" . }}-pvc-ohstatic
+  namespace: oh-staff{{ .Values.django.env.run_env }}
+spec:
+  accessModes:
+    - {{ .Values.persistentVolumes.ohstatic.access }}
+  storageClassName: ""
+  resources:
+    requests:
+      storage: {{ .Values.persistentVolumes.ohstatic.storage }}
+  volumeName: {{ include "oh-staff.fullname" . }}-pv-ohstatic

--- a/charts/templates/pvc-ohwowza.yaml
+++ b/charts/templates/pvc-ohwowza.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "oh-staff.fullname" . }}-pvc-ohwowza
+  namespace: oh-staff{{ .Values.django.env.run_env }}
+spec:
+  accessModes:
+    - {{ .Values.persistentVolumes.ohwowza.access }}
+  storageClassName: ""
+  resources:
+    requests:
+      storage: {{ .Values.persistentVolumes.ohwowza.storage }}
+  volumeName: {{ include "oh-staff.fullname" . }}-pv-ohwowza

--- a/charts/templates/secrets.yaml
+++ b/charts/templates/secrets.yaml
@@ -1,0 +1,13 @@
+{{ if not .Values.django.externalSecrets.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "oh-staff.fullname" . }}-secrets
+  namespace: oh-staff{{ .Values.django.env.run_env }}
+  labels:
+{{ include "oh-staff.fullname" . | indent 4 }}
+type: Opaque
+data:
+  DJANGO_SECRET_KEY: {{ randAlphaNum 20 | b64enc | quote }}
+  DJANGO_DB_PASSWORD: {{ .Values.django.env.db_password | b64enc | quote }}
+{{ end }}

--- a/charts/templates/service.yaml
+++ b/charts/templates/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "oh-staff.fullname" . }}
+  namespace: oh-staff{{ .Values.django.env.run_env }}
+  labels:
+    {{- include "oh-staff.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.django.env.target_port | default "8000" }}
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "oh-staff.selectorLabels" . | nindent 4 }}

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -13,8 +13,7 @@ nameOverride: ""
 fullnameOverride: ""
 
 service:
-  type: NodePort
-  port: 80
+  type: ClusterIP
 
 ingress:
   enabled: false

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -1,0 +1,110 @@
+# Default values for oh-staff.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: uclalibrary/oral-history-staff-ui
+  tag: latest
+  pullPolicy: Always
+
+nameOverride: ""
+fullnameOverride: ""
+
+service:
+  type: NodePort
+  port: 80
+
+ingress:
+  enabled: false
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: chart-example.local
+      paths: []
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+django:
+  env:
+    run_env: "prod"
+    debug: "false"
+    log_level: ""
+    allowed_hosts: []
+    #  - localhost
+    #  - 127.0.0.1
+    #  - [::1]
+    csrf_trusted_origins: []
+    ark_minter: ""
+    db_backend: ""
+    db_host: ""
+    db_port: ""
+    db_name: ""
+    db_user: ""
+    # Include if externalSecrets enabled: "false"
+    #db_password: ""
+    oh_file_source: ""
+    target_port: ""
+    oh_libpartners: ""
+    oh_masterslz: ""
+    oh_static: ""
+    oh_wowza: ""
+    use_test_dirs: ""
+
+  externalSecrets:
+    enabled: "false"
+    env: {}
+    # Include below if enabled: "true"
+    #  db_password: ""
+    #  django_secret_key: ""
+
+# PersistentVolume and PersistentVolumeClaim parameters
+persistentVolumes:
+  ohsource:
+    storage: ""
+    access: ""
+    server: ""
+    path: ""
+  ohmasters:
+    storage: ""
+    access: ""
+    server: ""
+    path: ""
+  ohwowza:
+    storage: ""
+    access: ""
+    server: ""
+    path: ""
+  ohstatic:
+    storage: ""
+    access: ""
+    server: ""
+    path: ""
+
+# Volume mount specification for the container
+volumeMounts: []
+#  - name: ""
+#    mountPath: ""
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+


### PR DESCRIPTION
Implements [SYS-1200](https://jira.library.ucla.edu/browse/SYS-1200).

This PR adds an initial version of the Helm chart for the Oral History Staff UI application, `oh-staff`.  It's intended for deployment in our production Rancher Kubernetes environment.

There are two external secrets defined.  Both have been created in our AWS parameter store.

This application will need access to the same persistent volumes as the existing [`dlcs-staff-ui`](https://github.com/UCLALibrary/dlcs-staff-ui/tree/main/charts) application, so I copied those templates as-is, changing just the application name/variables.  This application will also need similar resources allocated, so I also used that data.
