### PR TITLE
SYS-1186: Fix error when searching for full ARK

### DIFF
--- a/oh_staff_ui/urls.py
+++ b/oh_staff_ui/urls.py
@@ -7,7 +7,7 @@ urlpatterns = [
     path("", views.add_item),  # TODO: Change this to something better.....
     path("item_search/", views.item_search, name="item_search"),
     path(
-        "search_results/<str:search_type>/<str:query>",
+        "search_results/<str:search_type>/<path:query>",
         views.search_results,
         name="search_results",
     ),


### PR DESCRIPTION
Implements [SYS-1186](https://jira.library.ucla.edu/browse/SYS-1186)

Changing the URL converter from `str` to `path` now allows search terms including forward slashes. Useful for full ARK search and title searches including dates (e.g. 11/18/2020).