### PR TITLE
SYS-1212: Allow parent to be specified when adding new records

### DIFF
--- a/oh_staff_ui/forms.py
+++ b/oh_staff_ui/forms.py
@@ -11,6 +11,7 @@ from oh_staff_ui.models import (
     Language,
     Name,
     NameType,
+    ProjectItem,
     Publisher,
     PublisherType,
     Resource,
@@ -22,7 +23,19 @@ from oh_staff_ui.models import (
 )
 
 
+class ProjectItemChoiceField(forms.ModelChoiceField):
+    def label_from_instance(self, item):
+        return f"{item.title} ({item.ark})"
+
+
 class ProjectItemForm(forms.Form):
+    parent = ProjectItemChoiceField(
+        required=False,
+        queryset=(
+            ProjectItem.objects.filter(type__type="Series")
+            | ProjectItem.objects.filter(type__type="Interview")
+        ).order_by("title"),
+    )
     title = forms.CharField(
         required=True, max_length=256, widget=forms.TextInput(attrs={"size": 80})
     )

--- a/oh_staff_ui/forms.py
+++ b/oh_staff_ui/forms.py
@@ -32,8 +32,7 @@ class ProjectItemForm(forms.Form):
     parent = ProjectItemChoiceField(
         required=False,
         queryset=(
-            ProjectItem.objects.filter(type__type="Series")
-            | ProjectItem.objects.filter(type__type="Interview")
+            ProjectItem.objects.filter(type__type__in=["Series", "Interview"])
         ).order_by("title"),
     )
     title = forms.CharField(

--- a/oh_staff_ui/templates/oh_staff_ui/edit_item.html
+++ b/oh_staff_ui/templates/oh_staff_ui/edit_item.html
@@ -13,6 +13,9 @@
         {{ item.parent }}
         {% endif %}
     </li>
+    {% if item.type.type == "Series" or item.type.type == "Interview" %}
+    <li><a href="{% url 'add_item_from_parent' item.id %}">Add a child item</a></li>
+    {% endif %}
 </ul>
 <ul class="tree">
     {% include "oh_staff_ui/item_tree.html" %}

--- a/oh_staff_ui/urls.py
+++ b/oh_staff_ui/urls.py
@@ -3,6 +3,7 @@ from . import views
 
 urlpatterns = [
     path("add_item/", views.add_item, name="add_item"),
+    path("add_item/<int:parent_id>", views.add_item, name="add_item_from_parent"),
     path("item/<int:item_id>", views.edit_item, name="edit_item"),
     path("", views.add_item),  # TODO: Change this to something better.....
     path("item_search/", views.item_search, name="item_search"),

--- a/oh_staff_ui/views.py
+++ b/oh_staff_ui/views.py
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 
 
 @login_required
-def add_item(request: HttpRequest) -> HttpResponse:
+def add_item(request: HttpRequest, parent_id=None) -> HttpResponse:
     if request.method == "POST":
         form = ProjectItemForm(request.POST)
         if form.is_valid():
@@ -55,7 +55,11 @@ def add_item(request: HttpRequest) -> HttpResponse:
                     {"form": form, "custom_errors": custom_errors},
                 )
     else:
-        form = ProjectItemForm()
+        if parent_id:
+            parent = ProjectItem.objects.get(id=parent_id)
+            form = ProjectItemForm(initial={"parent": parent})
+        else:
+            form = ProjectItemForm()
         return render(request, "oh_staff_ui/add_item.html", {"form": form})
 
 

--- a/oh_staff_ui/views.py
+++ b/oh_staff_ui/views.py
@@ -34,6 +34,7 @@ def add_item(request: HttpRequest) -> HttpResponse:
                 user = request.user
                 new_item = ProjectItem(
                     ark=ark,
+                    parent=form.cleaned_data["parent"],
                     sequence=form.cleaned_data["sequence"],
                     title=form.cleaned_data["title"],
                     type=form.cleaned_data["type"],

--- a/oh_staff_ui/views_utils.py
+++ b/oh_staff_ui/views_utils.py
@@ -81,6 +81,7 @@ def get_edit_item_context(item_id: int) -> dict:
     # item_form is "bound" with this data
     item_form = ProjectItemForm(
         data={
+            "parent": item.parent,
             "title": item.title,
             "type": item.type,
             "sequence": item.sequence,

--- a/oh_staff_ui/views_utils.py
+++ b/oh_staff_ui/views_utils.py
@@ -219,6 +219,7 @@ def save_all_item_data(item_id: int, request: HttpRequest) -> None:
         # Item data
         item = ProjectItem.objects.get(pk=item_id)
         item.coverage = item_form.cleaned_data["coverage"]
+        item.parent = item_form.cleaned_data["parent"]
         item.relation = item_form.cleaned_data["relation"]
         item.sequence = item_form.cleaned_data["sequence"]
         item.status = item_form.cleaned_data["status"]


### PR DESCRIPTION
Implements [SYS-1212](https://jira.library.ucla.edu/browse/SYS-1212)

These changes allow any ProjectItem with Type "Series" or "Interview" to be selected as the parent when adding a new item. This is done with a dropdown field at the top of the add_item form. 
Additionally, a new link called "Add a child item" has been added to the top of the item display page for Series and Interviews. Clicking this link should take the user to the add_item form with the Parent dropdown already set. 

This does not allow moving children to new parents at this point.