### PR TITLE
SYS-1204: Enable dynamic repeatable fields

### DIFF
--- a/charts/prod-ohstaff-values.yaml
+++ b/charts/prod-ohstaff-values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: uclalibrary/oral-history-staff-ui
-  tag: v0.2.0
+  tag: v0.3.0
   pullPolicy: Always
 
 nameOverride: ""

--- a/oh_staff_ui/templates/oh_staff_ui/base.html
+++ b/oh_staff_ui/templates/oh_staff_ui/base.html
@@ -3,7 +3,10 @@
 <html>
 
 <head>
-<link rel="stylesheet" type="text/css" href="{% static 'css/style.css' %}"/>
+    <!-- Custom CSS -->
+    <link rel="stylesheet" type="text/css" href="{% static 'css/style.css' %}"/>
+    <!-- Custom JS -->
+    <script src="{% static 'js/main.js' %}" defer></script>
 </head>
 
 <body>

--- a/oh_staff_ui/templates/oh_staff_ui/edit_item.html
+++ b/oh_staff_ui/templates/oh_staff_ui/edit_item.html
@@ -35,95 +35,194 @@
     {{ description_formset.management_form }}
     {{ date_formset.management_form }}
     {{ format_formset.management_form }}
-    <table>
+    <table id="formset_table">
         {% for name_form in name_formset %}
         <tr>
-            <td>{% if forloop.first %}Name(s):{% endif %}</td>
+            <td>{% if forloop.first %}
+                <button id="name_add" class="add_formset">+</button>&nbsp;Name(s):
+                {% endif %}
+            </td>
             <td>{{ name_form.usage_id }} {{ name_form.type }}</td>
             <td>{{ name_form.value }}</td>
             <td>Delete? {{ name_form.DELETE }}</td>
         </tr>
         {% endfor %}
+        <tr id="name_empty_form" class="empty_form">
+            <td></td>
+            <td>{{ name_formset.empty_form.usage_id }} {{ name_formset.empty_form.type }}</td>
+            <td>{{ name_formset.empty_form.value }}</td>
+            <td>Delete? {{ name_formset.empty_form.DELETE }}</td>
+        </tr>
         {% for subject_form in subject_formset %}
         <tr>
-            <td>{% if forloop.first %}Subject(s):{% endif %}</td>
+            <td>{% if forloop.first %}
+                <button id="subject_add" class="add_formset">+</button>&nbsp;Subject(s):
+                {% endif %}
+            </td>
             <td>{{ subject_form.usage_id }} {{ subject_form.type }}</td>
             <td>{{ subject_form.value }}</td>
             <td>Delete? {{ subject_form.DELETE }}</td>
         </tr>
         {% endfor %}
+        <tr id="subject_empty_form" class="empty_form">
+            <td></td>
+            <td>{{ subject_formset.empty_form.usage_id }} {{ subject_formset.empty_form.type }}</td>
+            <td>{{ subject_formset.empty_form.value }}</td>
+            <td>Delete? {{ subject_formset.empty_form.DELETE }}</td>
+        </tr>
         {% for publisher_form in publisher_formset %}
         <tr>
-            <td>{% if forloop.first %}Publisher(s):{% endif %}</td>
+            <td>{% if forloop.first %}
+                <button id="publisher_add" class="add_formset">+</button>&nbsp;Publisher(s):
+                {% endif %}
+            </td>
             <td>{{ publisher_form.usage_id }} {{ publisher_form.type }}</td>
             <td>{{ publisher_form.value }}</td>
             <td>Delete? {{ publisher_form.DELETE }}</td>
         </tr>
         {% endfor %}
+        <tr id="publisher_empty_form" class="empty_form">
+            <td></td>
+            <td>{{ publisher_formset.empty_form.usage_id }} {{ publisher_formset.empty_form.type }}</td>
+            <td>{{ publisher_formset.empty_form.value }}</td>
+            <td>Delete? {{ publisher_formset.empty_form.DELETE }}</td>
+        </tr>
         {% for copyright_form in copyright_formset %}
         <tr>
-            <td>{% if forloop.first %}Copyright(s):{% endif %}</td>
+            <td>{% if forloop.first %}
+                <button id="copyright_add" class="add_formset">+</button>&nbsp;Copyright(s):
+                {% endif %}
+            </td>
             <td>{{ copyright_form.usage_id }} {{ copyright_form.type }}</td>
             <td>{{ copyright_form.value }}</td>
             <td>Delete? {{ copyright_form.DELETE }}</td>
         </tr>
         {% endfor %}
+        <tr id="copyright_empty_form" class="empty_form">
+            <td></td>
+            <td>{{ copyright_formset.empty_form.usage_id }} {{ copyright_formset.empty_form.type }}</td>
+            <td>{{ copyright_formset.empty_form.value }}</td>
+            <td>Delete? {{ copyright_formset.empty_form.DELETE }}</td>
+        </tr>
         {% for resource_form in resource_formset %}
         <tr>
-            <td>{% if forloop.first %}Resource(s):{% endif %}</td>
+            <td>{% if forloop.first %}
+                <button id="resource_add" class="add_formset">+</button>&nbsp;Resource(s):
+                {% endif %}
+            </td>
             <td>{{ resource_form.usage_id }} {{ resource_form.type }}</td>
             <td>{{ resource_form.value }}</td>
             <td>Delete? {{ resource_form.DELETE }}</td>
         </tr>
         {% endfor %}
+        <tr id="resource_empty_form" class="empty_form">
+            <td></td>
+            <td>{{ resource_formset.empty_form.usage_id }} {{ resource_formset.empty_form.type }}</td>
+            <td>{{ resource_formset.empty_form.value }}</td>
+            <td>Delete? {{ resource_formset.empty_form.DELETE }}</td>
+        </tr>
         {% for alt_title_form in alt_title_formset %}
         <tr>
-            <td>{% if forloop.first %}Alt Title(s):{% endif %}</td>
+            <td>{% if forloop.first %}
+                <button id="alt_title_add" class="add_formset">+</button>&nbsp;Alt Title(s):
+                {% endif %}
+            </td>
             <td>{{ alt_title_form.usage_id }} {{ alt_title_form.type }}</td>
             <td>{{ alt_title_form.value }}</td>
             <td>Delete? {{ alt_title_form.DELETE }}</td>
         </tr>
         {% endfor %}
+        <tr id="alt_title_empty_form" class="empty_form">
+            <td></td>
+            <td>{{ alt_title_formset.empty_form.usage_id }} {{ alt_title_formset.empty_form.type }}</td>
+            <td>{{ alt_title_formset.empty_form.value }}</td>
+            <td>Delete? {{ alt_title_formset.empty_form.DELETE }}</td>
+        </tr>
         {% for alt_id_form in alt_id_formset %}
         <tr>
-            <td>{% if forloop.first %}Alt ID(s):{% endif %}</td>
+            <td>{% if forloop.first %}
+                <button id="alt_id_add" class="add_formset">+</button>&nbsp;Alt ID(s):
+                {% endif %}
+            </td>
             <td>{{ alt_id_form.usage_id }} {{ alt_id_form.type }}</td>
             <td>{{ alt_id_form.value }}</td>
             <td>Delete? {{ alt_id_form.DELETE }}</td>
         </tr>
         {% endfor %}
+        <tr id="alt_id_empty_form" class="empty_form">
+            <td></td>
+            <td>{{ alt_id_formset.empty_form.usage_id }} {{ alt_id_formset.empty_form.type }}</td>
+            <td>{{ alt_id_formset.empty_form.value }}</td>
+            <td>Delete? {{ alt_id_formset.empty_form.DELETE }}</td>
+        </tr>
         {% for description_form in description_formset %}
         <tr>
-            <td>{% if forloop.first %}Description(s):{% endif %}</td>
+            <td>{% if forloop.first %}
+                <button id="description_add" class="add_formset">+</button>&nbsp;Description(s):
+                {% endif %}
+            </td>
             <td>{{ description_form.usage_id }} {{ description_form.type }}</td>
             <td>{{ description_form.value }}</td>
             <td>Delete? {{ description_form.DELETE }}</td>
         </tr>
         {% endfor %}
+        <tr id="description_empty_form" class="empty_form">
+            <td></td>
+            <td>{{ description_formset.empty_form.usage_id }} {{ description_formset.empty_form.type }}</td>
+            <td>{{ description_formset.empty_form.value }}</td>
+            <td>Delete? {{ description_formset.empty_form.DELETE }}</td>
+        </tr>
         {% for date_form in date_formset %}
         <tr>
-            <td>{% if forloop.first %}Date(s):{% endif %}</td>
+            <td>{% if forloop.first %}
+                <button id="date_add" class="add_formset">+</button>&nbsp;Date(s):
+                {% endif %}
+            </td>
             <td>{{ date_form.usage_id }} {{ date_form.type }}</td>
             <td>{{ date_form.value }}</td>
             <td>Delete? {{ date_form.DELETE }}</td>
         </tr>
         {% endfor %}
+        <tr id="date_empty_form" class="empty_form">
+            <td></td>
+            <td>{{ date_formset.empty_form.usage_id }} {{ date_formset.empty_form.type }}</td>
+            <td>{{ date_formset.empty_form.value }}</td>
+            <td>Delete? {{ date_formset.empty_form.DELETE }}</td>
+        </tr>
         {% for language_form in language_formset %}
         <tr>
-            <td>{% if forloop.first %}Language(s):{% endif %}</td>
+            <td>{% if forloop.first %}
+                <button id="language_add" class="add_formset">+</button>&nbsp;Language(s):
+                {% endif %}
+            </td>
             <td>{{ language_form.usage_id }}</td>
             <td>{{ language_form.value }}</td>
             <td>Delete? {{ language_form.DELETE }}</td>
         </tr>
         {% endfor %}
+        <tr id="language_empty_form" class="empty_form">
+            <td></td>
+            <td>{{ language_formset.empty_form.usage_id }}</td>
+            <td>{{ language_formset.empty_form.value }}</td>
+            <td>Delete? {{ language_formset.empty_form.DELETE }}</td>
+        </tr>
         {% for format_form in format_formset %}
         <tr>
-            <td>{% if forloop.first %}Format(s):{% endif %}</td>
+            <td>{% if forloop.first %}
+                <button id="format_add" class="add_formset">+</button>&nbsp;Format(s):
+                {% endif %}
+            </td>
             <td>{{ format_form.usage_id }}</td>
             <td>{{ format_form.value }}</td>
             <td>Delete? {{ format_form.DELETE }}</td>
         </tr>
         {% endfor %}
+        <tr id="format_empty_form" class="empty_form">
+            <td></td>
+            <td>{{ format_formset.empty_form.usage_id }}</td>
+            <td>{{ format_formset.empty_form.value }}</td>
+            <td>Delete? {{ format_formset.empty_form.DELETE }}</td>
+        </tr>
     </table>
     <br>
     <button type="submit">Save</button>

--- a/oh_staff_ui/views_utils.py
+++ b/oh_staff_ui/views_utils.py
@@ -137,8 +137,7 @@ def get_edit_item_context(item_id: int) -> dict:
 def get_metadata_formset(
     item_id: int, form: Form, model: Model, prefix: str
 ) -> BaseFormSet:
-    """Return formset for given item and model, with initial data from database."""
-    factory = formset_factory(form, extra=1, can_delete=True)
+    """Return formset for given item and model, with initial data (if any) from database."""
     # Build list of dictionaries of initial values.
     objs = model.objects.filter(item=item_id).order_by("id")
     obj_list = []
@@ -152,6 +151,10 @@ def get_metadata_formset(
         if hasattr(obj, "type"):
             data_dict["type"] = obj.type
         obj_list.append(data_dict)
+    # Show empty form by default only when there's no real data already (extra=1).
+    # Otherwise, show only real data (extra=0).
+    extra_forms = 0 if len(obj_list) else 1
+    factory = formset_factory(form, extra=extra_forms, can_delete=True)
     # formset is "unbound" with this initial data
     formset = factory(initial=obj_list, prefix=prefix)
     return formset

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -13,3 +13,7 @@
 td {
     vertical-align: top;
 }
+
+.empty_form {
+    display: none;
+}

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -1,0 +1,29 @@
+let buttons = document.querySelectorAll("button.add_formset");
+buttons.forEach(btn => btn.addEventListener("click", showEmptyForm));
+
+function showEmptyForm(event) {
+    // Prevent button default behavior of submitting form.
+    event.preventDefault();
+    // Get metadata type from button id.
+    metadataType = this.id.replace("_add", "");
+    // Find current number of forms being used for this type.
+    totalId = `id_${metadataType}s-TOTAL_FORMS`;
+    total = document.getElementById(totalId);
+
+    // Find empty form for this type.
+    emptyForm = document.getElementById(metadataType + "_empty_form");
+    // Clone it to make a new form for display.
+    newForm = emptyForm.cloneNode(deep=true);
+    // Update numeric prefix values for new form, using original total.
+    // E.g., if total is 1 (1 existing form), the new form is the 2nd form,
+    // so it will use (0-based) number 1.
+    newFormNumber = total.value;
+    newForm.innerHTML = newForm.innerHTML.replace(/__prefix__/g, newFormNumber);
+    // Remove id & class, copied from emptyForm
+    newForm.removeAttribute("id");
+    newForm.classList.remove("empty_form");
+    // Display the new form immediately before the (hidden) empty form.
+    emptyForm.parentNode.insertBefore(newForm, emptyForm);
+    // Finally, increment total forms for this type.
+    total.value = Number(total.value) + 1;
+}

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -4,26 +4,37 @@ buttons.forEach(btn => btn.addEventListener("click", showEmptyForm));
 function showEmptyForm(event) {
     // Prevent button default behavior of submitting form.
     event.preventDefault();
-    // Get metadata type from button id.
+    
+    // Get metadata type from button id (e.g., name_add -> name).
     metadataType = this.id.replace("_add", "");
+    
     // Find current number of forms being used for this type.
+    // This comes from the hidden "management form" for the given type.
+    // E.g., id_names_TOTAL_FORMS
     totalId = `id_${metadataType}s-TOTAL_FORMS`;
     total = document.getElementById(totalId);
 
     // Find empty form for this type.
+    // E.g., name -> name_empty_form
     emptyForm = document.getElementById(metadataType + "_empty_form");
+    
     // Clone it to make a new form for display.
     newForm = emptyForm.cloneNode(deep=true);
+    
     // Update numeric prefix values for new form, using original total.
-    // E.g., if total is 1 (1 existing form), the new form is the 2nd form,
-    // so it will use (0-based) number 1.
+    // E.g., for the new 2nd form (0-based):
+    // names-__prefix__-usage_id -> names-1-usage_id
     newFormNumber = total.value;
     newForm.innerHTML = newForm.innerHTML.replace(/__prefix__/g, newFormNumber);
+    
     // Remove id & class, copied from emptyForm
     newForm.removeAttribute("id");
     newForm.classList.remove("empty_form");
+    
     // Display the new form immediately before the (hidden) empty form.
     emptyForm.parentNode.insertBefore(newForm, emptyForm);
+    
     // Finally, increment total forms for this type.
+    // E.g., if there are now 2 name forms, value will change from 1 -> 2.
     total.value = Number(total.value) + 1;
 }


### PR DESCRIPTION
Implements [SYS-1204](https://jira.library.ucla.edu/browse/SYS-1204).

This PR adds dynamic repeatable fields to the item editing form.  It allows the editor to create any number of names, subjects, descriptions etc., without having to save and submit the form after each one.  It does this by using javascript to clone a hidden Django `formset.empty_form`.  The javascript updates the DOM and the hidden `TOTAL_FORMS` value which Django uses to confirm the correct number of sets of form data was received.

The `edit_item` template now has an extra row for each metadata type, like `<tr id="name_empty_form" class="empty_form">`.  This is largely duplicate code, but I don't see a way to output both the "real" form data for display and the hidden empty form, using Django's template language, without duplicate code.  `formset.empty_form` is not a form itself, so can't be output when iterating over `for form in formset`.

Bumps version to `v0.3.0`.

Testing:
* No migrations required.
* Create a new item, or retrieve any existing one.
* Use the `+` buttons next to each metadata type to add any number of new form elements.
* Fill out some / all new forms.
* Combine with editing existing form data, deleting some as well.  
* Try as many different combinations as possible.
* After clicking `Save`, confirm data was added / updated / deleted as requested.
