### PR TITLE
SYS-1205: javascript validation for edit_item form

### DIFF
--- a/oh_staff_ui/templates/oh_staff_ui/base.html
+++ b/oh_staff_ui/templates/oh_staff_ui/base.html
@@ -7,6 +7,7 @@
     <link rel="stylesheet" type="text/css" href="{% static 'css/style.css' %}"/>
     <!-- Custom JS -->
     <script src="{% static 'js/main.js' %}" defer></script>
+    <script src="{% static 'js/validation.js' %}" defer></script>
 </head>
 
 <body>

--- a/oh_staff_ui/templates/oh_staff_ui/edit_item.html
+++ b/oh_staff_ui/templates/oh_staff_ui/edit_item.html
@@ -20,7 +20,7 @@
 <ul class="tree">
     {% include "oh_staff_ui/item_tree.html" %}
 </ul>
-<form name="edit_item" onsubmit="return validateForm()" id="edit_item" method="POST">
+<form name="edit_item" onsubmit="return validateEditItemForm()" id="edit_item" method="POST">
     {% csrf_token %}
     {{ item_form.as_div }}
     <br>

--- a/oh_staff_ui/templates/oh_staff_ui/edit_item.html
+++ b/oh_staff_ui/templates/oh_staff_ui/edit_item.html
@@ -20,7 +20,7 @@
 <ul class="tree">
     {% include "oh_staff_ui/item_tree.html" %}
 </ul>
-<form name="edit_item" id="edit_item" method="POST">
+<form name="edit_item" onsubmit="return validateForm()" id="edit_item" method="POST">
     {% csrf_token %}
     {{ item_form.as_div }}
     <br>

--- a/static/js/validation.js
+++ b/static/js/validation.js
@@ -15,7 +15,7 @@ function validateForm(){
         // if exactly one exists, alert user of the problem and do not submit form
         for (let j=0; j<types.length; j++) {
             if ((types[j].value && !values[j].value) || (values[j].value && !types[j].value)){
-                alert(`Please enter both a type and value for ${formattedNames[i]}.`)
+                alert(`Please enter both a qualifier and value for ${formattedNames[i]}.`)
                 return false
             }
         }

--- a/static/js/validation.js
+++ b/static/js/validation.js
@@ -1,0 +1,23 @@
+function validateForm(){
+    // all "optional" metadata other than Language and Format, which don't have types
+    const valuesToCheck = ["alt_id","alt_title","copyright","date","description","name","publisher","resource","subject"]
+    // more human-readable names, in the same order, for display
+    const formattedNames = ["Alt ID","Alt Title","Copyright","Date","Description","Name","Publisher","Resource","Subject"]
+
+    for (let i = 0; i < valuesToCheck.length; i++) {
+        // find the type and value inputs for each data type, ignoring hidden or "__prefix__"
+        typeQuery=`[name^=${valuesToCheck[i]}s][name$="type"]:not([name*="prefix"])`
+        valueQuery=`[name^=${valuesToCheck[i]}s][name$="value"]:not([name*="prefix"])`
+        types = document.querySelectorAll(typeQuery)
+        values = document.querySelectorAll(valueQuery)
+
+        // for each type, check existence of type and value
+        // if exactly one exists, alert user of the problem and do not submit form
+        for (let j=0; j<types.length; j++) {
+            if ((types[j].value && !values[j].value) || (values[j].value && !types[j].value)){
+                alert(`Please enter both a type and value for ${formattedNames[i]}.`)
+                return false
+            }
+        }
+    }
+}

--- a/static/js/validation.js
+++ b/static/js/validation.js
@@ -1,4 +1,4 @@
-function validateForm(){
+function validateEditItemForm(){
     // all "optional" metadata other than Language and Format, which don't have types
     const valuesToCheck = ["alt_id","alt_title","copyright","date","description","name","publisher","resource","subject"]
     // more human-readable names, in the same order, for display
@@ -13,9 +13,9 @@ function validateForm(){
 
         // for each type, check existence of type and value
         // if exactly one exists, alert user of the problem and do not submit form
-        for (let j=0; j<types.length; j++) {
-            if ((types[j].value && !values[j].value) || (values[j].value && !types[j].value)){
-                alert(`Please enter both a qualifier and value for ${formattedNames[i]}.`)
+        for (let j = 0; j < types.length; j++) {
+            if ((types[j].value && !values[j].value) || (values[j].value && !types[j].value)) {
+                alert(`Please enter both a qualifier and a value for ${formattedNames[i]}.`)
                 return false
             }
         }


### PR DESCRIPTION
Implements [SYS-1205](https://jira.library.ucla.edu/browse/SYS-1205)

Adds a javascript function to the edit_item form that checks, for metadata fields with both a "qualifier" and "value", that either neither or both fields has been filled out. If exactly one of the two fields has a value, a browser alert is shown indicating the metadata type needing review and the form is not submitted. 

Currently, only one problem is reported at a time, so users may need to revise their input multiple times before a submission is successful.