### PR TITLE
SYS-1233: Show logs in web UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,13 @@ The current log format includes:
 * Module: somewhat redundant with logger name
 * Message: The main thing being logged
 
+#### Viewing the log
+Local development environment: `view logs/application.log`.
+
+In deployed container:
+* `/logs/`: see latest 200 lines of the log
+* `/logs/nnn`: see latest `nnn` lines of the log
+
 ### Testing
 
 Tests focus on code which has significant side effects, like creating & changing files.  Run tests in the container:

--- a/charts/prod-ohstaff-values.yaml
+++ b/charts/prod-ohstaff-values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: uclalibrary/oral-history-staff-ui
-  tag: v0.4.0
+  tag: v0.4.5
   pullPolicy: Always
 
 nameOverride: ""

--- a/oh_staff_ui/templates/oh_staff_ui/base.html
+++ b/oh_staff_ui/templates/oh_staff_ui/base.html
@@ -11,7 +11,7 @@
 </head>
 
 <body>
-    <p>Temporary: <a href="/item_search/">Search</a>&nbsp;<a href="/admin/">Admin</a>&nbsp;<a href="/admin/logout/">Logout</a></p>
+    <p>Temporary: <a href="/item_search/">Search</a>&nbsp;<a href="/admin/">Admin</a>&nbsp;<a href="/logs/">Logs</a>&nbsp;<a href="/admin/logout/">Logout</a></p>
     {% block content %}
     {% endblock %}
 </body>

--- a/oh_staff_ui/templates/oh_staff_ui/log.html
+++ b/oh_staff_ui/templates/oh_staff_ui/log.html
@@ -1,0 +1,8 @@
+{% extends 'oh_staff_ui/base.html' %}
+
+{% block content %}
+<h3>Super QAD Log Dumper</h3>
+<pre>
+{{ log_data }}
+</pre>
+{% endblock %}

--- a/oh_staff_ui/urls.py
+++ b/oh_staff_ui/urls.py
@@ -12,4 +12,6 @@ urlpatterns = [
         views.search_results,
         name="search_results",
     ),
+    path("logs/", views.show_log, name="show_log"),
+    path("logs/<int:line_count>", views.show_log, name="show_log"),
 ]

--- a/oh_staff_ui/views.py
+++ b/oh_staff_ui/views.py
@@ -97,3 +97,18 @@ def search_results(request: HttpRequest, search_type: str, query: str) -> HttpRe
             ProjectItem.objects.filter(ark__icontains=query).order_by("ark").values()
         )
     return render(request, "oh_staff_ui/search_results.html", {"results": results})
+
+
+@login_required
+def show_log(request, line_count: int = 200) -> HttpResponse:
+    log_file = "logs/application.log"
+    try:
+        with open(log_file, "r") as f:
+            # Get just the last line_count lines in the log.
+            lines = f.readlines()[-line_count:]
+            # Template prints these as a single block, so join lines into one chunk.
+            log_data = "".join(lines)
+    except FileNotFoundError:
+        log_data = f"Log file {log_file} not found"
+
+    return render(request, "oh_staff_ui/log.html", {"log_data": log_data})


### PR DESCRIPTION
Implements [SYS-1233](https://jira.library.ucla.edu/browse/SYS-1233).

This adds a basic way to view the application log via browser, which is mainly useful with the deployed application, since developers do not currently have access to production containers or their logs.

By default, the latest 200 lines of the application log can be viewed at `/logs/`.  This can be changed by editing the URL; for example, `/logs/500` would show the latest 500 lines of the log.

Added this info to `README.md`.
Bumped version to `v0.4.5` for deployment.
