### PR TITLE
SYS-1228: Implement basic file saving

### DIFF
--- a/charts/prod-ohstaff-values.yaml
+++ b/charts/prod-ohstaff-values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: uclalibrary/oral-history-staff-ui
-  tag: v0.4.5
+  tag: v0.5.0
   pullPolicy: Always
 
 nameOverride: ""

--- a/oh_staff_ui/templates/oh_staff_ui/edit_item.html
+++ b/oh_staff_ui/templates/oh_staff_ui/edit_item.html
@@ -1,6 +1,7 @@
 {% extends 'oh_staff_ui/base.html' %}
 
 {% block content %}
+<a href="{% url 'upload_file' item.id %}">View files</a>
 <ul>
     <li>id: {{ item.id }}</li>
     <li>ARK: {{ item.ark }}</li>

--- a/oh_staff_ui/templates/oh_staff_ui/upload_file.html
+++ b/oh_staff_ui/templates/oh_staff_ui/upload_file.html
@@ -1,0 +1,38 @@
+{% extends 'oh_staff_ui/base.html' %}
+
+{% block content %}
+<a href="{% url 'edit_item' item.id %}">View metadata</a>
+<ul>
+  <li>id: {{ item.id }}</li>
+  <li>ARK: {{ item.ark }}</li>
+  <li>created: {{ item.create_date }} by {{ item.created_by }}</li>
+  <li>updated: {{ item.last_modified_date }} by {{ item.last_modified_by }}</li>
+  <li>Parent:
+      {% if item.parent %}
+      <a href="{% url 'edit_item' item.parent.id %}">{{ item.parent }}</a>
+      {% else %}
+      {{ item.parent }}
+      {% endif %}
+  </li>
+</ul>
+
+<table class="search-results">
+  {% for file in files %}
+  <tr>
+    <td>{{ file.file_type }}</td>
+    <td>{{ file.file.name }}</td>
+  </tr>
+  {% endfor %}
+</table>
+<br>
+<form name="upload_file_form" method="POST" enctype="multipart/form-data" onsubmit="disable_upload_button(this);">
+    {% csrf_token %}
+    <table>
+      <tr>
+        <td>{{ form.file_group }}</td>
+        <td>{{ form.file_name }}</td>
+      </tr>
+    </table>
+    <button type="submit" id="upload_button">Upload</button>
+</form>
+{% endblock %}

--- a/oh_staff_ui/urls.py
+++ b/oh_staff_ui/urls.py
@@ -14,4 +14,5 @@ urlpatterns = [
     ),
     path("logs/", views.show_log, name="show_log"),
     path("logs/<int:line_count>", views.show_log, name="show_log"),
+    path("upload_file/<int:item_id>", views.upload_file, name="upload_file"),
 ]

--- a/samples/fake_file_01.wav
+++ b/samples/fake_file_01.wav
@@ -1,0 +1,1 @@
+fake file 01

--- a/samples/fake_file_02.wav
+++ b/samples/fake_file_02.wav
@@ -1,0 +1,1 @@
+fake file 02

--- a/samples/fake_file_03.wav
+++ b/samples/fake_file_03.wav
@@ -1,0 +1,1 @@
+fake file 03

--- a/samples/fake_file_04.wav
+++ b/samples/fake_file_04.wav
@@ -1,0 +1,1 @@
+fake file 04

--- a/samples/fake_file_05.wav
+++ b/samples/fake_file_05.wav
@@ -1,0 +1,1 @@
+fake file 05

--- a/samples/fake_file_06.wav
+++ b/samples/fake_file_06.wav
@@ -1,0 +1,1 @@
+fake file 06

--- a/samples/fake_file_07.wav
+++ b/samples/fake_file_07.wav
@@ -1,0 +1,1 @@
+fake file 07

--- a/samples/fake_file_08.wav
+++ b/samples/fake_file_08.wav
@@ -1,0 +1,1 @@
+fake file 08

--- a/samples/fake_file_09.wav
+++ b/samples/fake_file_09.wav
@@ -1,0 +1,1 @@
+fake file 09

--- a/samples/fake_file_10.wav
+++ b/samples/fake_file_10.wav
@@ -1,0 +1,1 @@
+fake file 10

--- a/samples/managed/.gitignore
+++ b/samples/managed/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -38,3 +38,11 @@ function showEmptyForm(event) {
     // E.g., if there are now 2 name forms, value will change from 1 -> 2.
     total.value = Number(total.value) + 1;
 }
+
+// Disable file upload submit button once clicked.
+// The button is restored to normal once Django completes processing and re-renders the form.
+function disable_upload_button(form) {
+	btn = form.elements.upload_button;
+	btn.textContent = "Please wait...";
+	btn.disabled = true;
+}


### PR DESCRIPTION
Implements [SYS-1228](https://jira.library.ucla.edu/browse/SYS-1228); bumps version to `v0.5.0`.

This PR adds the ability for editors to select and "upload" files, associating them with items.  Files are not really uploaded (transferred from local machine via browser & network to server); instead, the user selects a file from a hard-coded directory on the server itself.  This reuses functionality from the phase 1 project.

For now, files are selected via form at `/upload_file/<item_id>`.  Users can switch between file and metadata forms by clicking `View metadata` or `View files`.

This does not implement file processing (converting audio wav files to mp3, or image tiffs to jpeg, etc.).  For now, the selected file is simply copied to the `samples/managed/` subdirectory, renamed, and a new `MediaFile` for that new file is associated with the current `ProjectItem`.  Proper file handling will be implemented in later tickets.

Known problems:
* New file names currently are based solely on item ARK and the selected file name.  If Django sees that a file with the same new name already exists in `samples/managed/`, it will make another copy with a new, Django-modified, name.  For example, if `samples/managed/21198-zz000906d5_fake_file_01.wav` already exists, Django will create a new file like `samples/managed/21198-zz000906d5_fake_file_01_XT5EfmP.wav` (or some other random characters appended).  This will be addressed later, once we talk about how to handle this...

Testing:
* Select any item
* Click `View files` to see the file upload form.
* Use the form to add files, one at a time.
  * As files are added, they display in a table above the form.
* If desired, review the data

```
# Added 3 files via UI form
$ ls -al samples/managed
-rw-r--r-- 1 akohler akohler    13 Apr 18 13:50 21198-zz000906d5_fake_file_01.wav
-rw-r--r-- 1 akohler akohler  2154 Apr 18 13:51 21198-zz000906d5_sample.pdf
-rw-r--r-- 1 akohler akohler 44144 Apr 18 13:51 21198-zz000906d5_sample.wav
-rw-r--r-- 1 akohler akohler    71 Apr 18 13:27 .gitignore

$ docker-compose exec django python manage.py shell
>>> from oh_staff_ui.models import MediaFile
>>> MediaFile.objects.all()
<QuerySet [<MediaFile: MediaFile object (11)>, <MediaFile: MediaFile object (12)>, <MediaFile: MediaFile object (13)>]>

>>> for f in MediaFile.objects.all():
...   # Delete file from disk
...   f.file.delete()
...   # Delete MediaFile itself
...   f.delete()
...
(1, {'oh_staff_ui.MediaFile': 1})
(1, {'oh_staff_ui.MediaFile': 1})
(1, {'oh_staff_ui.MediaFile': 1})

>>> MediaFile.objects.all()
<QuerySet []>

>>> exit()

# Files have been deleted
$ ls -al samples/managed
-rw-r--r-- 1 akohler akohler    71 Apr 18 13:27 .gitignore
```
