### PR TITLE
SYS-1239: Prevent duplicate uploads

### DIFF
--- a/oh_staff_ui/forms.py
+++ b/oh_staff_ui/forms.py
@@ -198,14 +198,19 @@ OH_FILE_SOURCE = os.getenv("DJANGO_OH_FILE_SOURCE")
 class FileUploadForm(forms.Form):
     file_group = forms.ModelChoiceField(
         queryset=MediaFileType.objects.all().order_by("file_type"),
-        empty_label="File type?",
+        empty_label="Please select a file type:",
+        label="File type:",
     )
     # FilePathField (at least) path gets cached automatically by Django at application startup.
     # There's no direct way to make it see changes to the filesystem; workaround from
     # https://stackoverflow.com/questions/30656653/suffering-stale-choices-for-filepathfield
 
     _file_name_kw = dict(
-        path=OH_FILE_SOURCE, recursive=True, allow_files=True, allow_folders=False
+        path=OH_FILE_SOURCE,
+        recursive=True,
+        allow_files=True,
+        allow_folders=False,
+        label="File:",
     )
     file_name = forms.FilePathField(**_file_name_kw)
 

--- a/oh_staff_ui/templates/oh_staff_ui/upload_file.html
+++ b/oh_staff_ui/templates/oh_staff_ui/upload_file.html
@@ -25,9 +25,22 @@
   {% endfor %}
 </table>
 <br>
+
+{% if messages %}
+<div class="box">
+{% for message in messages %}
+  {{ message }}
+{% endfor %}
+</div>
+{% endif %}
+
 <form name="upload_file_form" method="POST" enctype="multipart/form-data" onsubmit="disable_upload_button(this);">
     {% csrf_token %}
     <table>
+      <tr>
+        <td>{{ form.file_group.label }}</td>
+        <td>{{ form.file_name.label }}</td>
+      </tr>
       <tr>
         <td>{{ form.file_group }}</td>
         <td>{{ form.file_name }}</td>

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -17,3 +17,9 @@ td {
 .empty_form {
     display: none;
 }
+
+.box {
+    margin: 10px;
+    padding: 10px;
+    border: 1px solid black;
+}


### PR DESCRIPTION
Implements [SYS-1239](https://jira.library.ucla.edu/browse/SYS-1239).

This PR prevents the same file from being associated with a given item multiple times.  If an editor tries, Django does not save the new `MediaFile`, and shows a message like this:
![oh_duplicate_file_message](https://user-images.githubusercontent.com/2213836/234077777-fa656255-e6d6-4016-9f90-fb67aaeced6f.png)

A new test was added which covers this.

Other changes include minor improvements to the file upload form display, and some code formatting changes and other minor cleanup.

Testing:
* Add a file to an item.
* Try to add the same file again to the item.  It should not be added, and a message to that effect should appear.
