### PR TITLE
SYS-1240: Improve "edit item" page appearance

### DIFF
--- a/oh_staff_ui/forms.py
+++ b/oh_staff_ui/forms.py
@@ -39,7 +39,7 @@ class ProjectItemForm(forms.Form):
         ).order_by("title"),
     )
     title = forms.CharField(
-        required=True, max_length=256, widget=forms.TextInput(attrs={"size": 80})
+        required=True, max_length=256, widget=forms.TextInput(attrs={"size": 140})
     )
     type = forms.ModelChoiceField(
         required=True,
@@ -50,10 +50,10 @@ class ProjectItemForm(forms.Form):
         required=True, max_length=3, widget=forms.TextInput(attrs={"size": 3})
     )
     coverage = forms.CharField(
-        required=False, max_length=256, widget=forms.TextInput(attrs={"size": 80})
+        required=False, max_length=256, widget=forms.TextInput(attrs={"size": 140})
     )
     relation = forms.CharField(
-        required=False, max_length=256, widget=forms.TextInput(attrs={"size": 80})
+        required=False, max_length=256, widget=forms.TextInput(attrs={"size": 140})
     )
     status = forms.ModelChoiceField(
         required=True,
@@ -145,7 +145,7 @@ class AltTitleForm(forms.Form):
         empty_label="Please select a qualifier:",
     )
     value = forms.CharField(
-        required=True, max_length=256, widget=forms.TextInput(attrs={"size": 80})
+        required=True, max_length=256, widget=forms.TextInput(attrs={"size": 100})
     )
 
 
@@ -156,7 +156,7 @@ class AltIdForm(forms.Form):
         empty_label="Please select a qualifier:",
     )
     value = forms.CharField(
-        required=True, max_length=256, widget=forms.TextInput(attrs={"size": 80})
+        required=True, max_length=256, widget=forms.TextInput(attrs={"size": 100})
     )
 
 
@@ -169,7 +169,7 @@ class DescriptionForm(forms.Form):
     value = forms.CharField(
         required=True,
         max_length=1024,
-        widget=forms.Textarea(attrs={"cols": 81, "rows": 3}),
+        widget=forms.Textarea(attrs={"cols": 98, "rows": 3}),
     )
 
 
@@ -180,14 +180,14 @@ class DateForm(forms.Form):
         empty_label="Please select a qualifier:",
     )
     value = forms.CharField(
-        required=True, max_length=256, widget=forms.TextInput(attrs={"size": 80})
+        required=True, max_length=256, widget=forms.TextInput(attrs={"size": 100})
     )
 
 
 class FormatForm(forms.Form):
     usage_id = forms.IntegerField(initial=0, widget=forms.HiddenInput())
     value = forms.CharField(
-        required=True, max_length=1024, widget=forms.TextInput(attrs={"size": 80})
+        required=True, max_length=1024, widget=forms.TextInput(attrs={"size": 100})
     )
 
 

--- a/oh_staff_ui/forms.py
+++ b/oh_staff_ui/forms.py
@@ -169,7 +169,7 @@ class DescriptionForm(forms.Form):
     value = forms.CharField(
         required=True,
         max_length=1024,
-        widget=forms.Textarea(attrs={"cols": 70, "rows": 3}),
+        widget=forms.Textarea(attrs={"cols": 81, "rows": 3}),
     )
 
 

--- a/oh_staff_ui/templates/oh_staff_ui/edit_item.html
+++ b/oh_staff_ui/templates/oh_staff_ui/edit_item.html
@@ -1,29 +1,55 @@
 {% extends 'oh_staff_ui/base.html' %}
 
 {% block content %}
-<a href="{% url 'upload_file' item.id %}">View files</a>
-<ul>
-    <li>id: {{ item.id }}</li>
-    <li>ARK: {{ item.ark }}</li>
-    <li>created: {{ item.create_date }} by {{ item.created_by }}</li>
-    <li>updated: {{ item.last_modified_date }} by {{ item.last_modified_by }}</li>
-    <li>Parent:
-        {% if item.parent %}
-        <a href="{% url 'edit_item' item.parent.id %}">{{ item.parent }}</a>
-        {% else %}
-        {{ item.parent }}
-        {% endif %}
-    </li>
-    {% if item.type.type == "Series" or item.type.type == "Interview" %}
-    <li><a href="{% url 'add_item_from_parent' item.id %}">Add a child item</a></li>
-    {% endif %}
-</ul>
-<ul class="tree">
-    {% include "oh_staff_ui/item_tree.html" %}
-</ul>
+
+<table class="header-metadata">
+    <caption>Item Information</caption>
+    <tr>
+        <td>Title</td>
+        <td>{{ item.title }}</td>
+    </tr>
+    <tr>
+        <td>ARK</td>
+        <td>{{ item.ark }}</td>
+    </tr>
+    <tr>
+        <td>Parent</td>
+        <td>{% if item.parent %}
+            <a href="{% url 'edit_item' item.parent.id %}">{{ item.parent }}</a>
+            {% else %}
+            {{ item.parent }}
+            {% endif %}</td>
+    </tr>
+    <tr>
+        <td>Created</td>
+        <td>{{ item.create_date }} by {{ item.created_by }}</td>
+    </tr>
+    <tr>
+        <td>Updated</td>
+        <td>{{ item.last_modified_date }} by {{ item.last_modified_by }}</td>
+    </tr>
+    <tr>
+        <td>Item Actions</td>
+        <td>
+            {% if item.type.type == "Series" or item.type.type == "Interview" %}
+            <a href="{% url 'add_item_from_parent' item.id %}">Add a child item</a>   |   
+            {% endif %}
+            <a href="{% url 'upload_file' item.id %}">View files</a>
+        </td>
+    </tr>
+</table>
+<div>
+    <p>Item Hierarchy Context (use arrow to expand)</p>
+    <ul class="tree">
+        {% include "oh_staff_ui/item_tree.html" %}
+    </ul>
+</div>
+<hr>
 <form name="edit_item" onsubmit="return validateEditItemForm()" id="edit_item" method="POST">
     {% csrf_token %}
+    <div class="basic_metadata">
     {{ item_form.as_div }}
+    </div>
     <br>
     {{ name_formset.management_form }}
     {{ subject_formset.management_form }}
@@ -190,23 +216,6 @@
             <td>{{ date_formset.empty_form.value }}</td>
             <td>Delete? {{ date_formset.empty_form.DELETE }}</td>
         </tr>
-        {% for language_form in language_formset %}
-        <tr>
-            <td>{% if forloop.first %}
-                <button id="language_add" class="add_formset">+</button>&nbsp;Language(s):
-                {% endif %}
-            </td>
-            <td>{{ language_form.usage_id }}</td>
-            <td>{{ language_form.value }}</td>
-            <td>Delete? {{ language_form.DELETE }}</td>
-        </tr>
-        {% endfor %}
-        <tr id="language_empty_form" class="empty_form">
-            <td></td>
-            <td>{{ language_formset.empty_form.usage_id }}</td>
-            <td>{{ language_formset.empty_form.value }}</td>
-            <td>Delete? {{ language_formset.empty_form.DELETE }}</td>
-        </tr>
         {% for format_form in format_formset %}
         <tr>
             <td>{% if forloop.first %}
@@ -223,6 +232,23 @@
             <td>{{ format_formset.empty_form.usage_id }}</td>
             <td>{{ format_formset.empty_form.value }}</td>
             <td>Delete? {{ format_formset.empty_form.DELETE }}</td>
+        </tr>
+        {% for language_form in language_formset %}
+        <tr>
+            <td>{% if forloop.first %}
+                <button id="language_add" class="add_formset">+</button>&nbsp;Language(s):
+                {% endif %}
+            </td>
+            <td>{{ language_form.usage_id }}</td>
+            <td>{{ language_form.value }}</td>
+            <td>Delete? {{ language_form.DELETE }}</td>
+        </tr>
+        {% endfor %}
+        <tr id="language_empty_form" class="empty_form">
+            <td></td>
+            <td>{{ language_formset.empty_form.usage_id }}</td>
+            <td>{{ language_formset.empty_form.value }}</td>
+            <td>Delete? {{ language_formset.empty_form.DELETE }}</td>
         </tr>
     </table>
     <br>

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -60,3 +60,10 @@ ul.tree {
 caption {
     font-weight: bold;
 }
+
+form select,
+form input,
+form textarea {
+    font-family: Helvetica, Arial, sans-serif;
+    font-size: 13.333px;
+}

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -23,3 +23,40 @@ td {
     padding: 10px;
     border: 1px solid black;
 }
+
+ form[name="edit_item"] div {
+     display: table-row;
+ }
+ 
+ form[name="edit_item"] label {
+     display: table-cell;
+ }
+
+ form[name="edit_item"] select,
+ form[name="edit_item"] input,
+ form[name="edit_item"] textarea {
+    margin-left: 10px;
+    margin-right: 5px;
+ }
+
+ form[name="edit_item"] .basic_metadata select,
+ form[name="edit_item"] .basic_metadata input,
+ form[name="edit_item"] .basic_metadata textarea {
+    margin-bottom: 3px;
+ }
+
+.header-metadata{
+    border-collapse: collapse;
+ }
+.header-metadata td{
+    padding: 4px;
+    border: 1px solid;
+}
+
+ul.tree {
+    margin-top: -10px;
+}
+
+caption {
+    font-weight: bold;
+}


### PR DESCRIPTION
Implements [SYS-1240](https://jira.library.ucla.edu/browse/SYS-1240)

Template, form, and CSS changes intended to give the edit item pages a more cohesive and comprehensible appearance. No functionality changes.

Please test in a couple of different browsers if you can. There are a number of differences between the page's appearance in Firefox and Chrome as it stands - let me know if I should better harmonize these. I've attempted to size things to comfortably fit items with long titles (like 21198/zz002jxz6f). 