### PR TITLE
SYS-1241: Improve links menu and admin navigation

### DIFF
--- a/oh_staff_ui/templates/oh_staff_ui/base.html
+++ b/oh_staff_ui/templates/oh_staff_ui/base.html
@@ -11,7 +11,13 @@
 </head>
 
 <body>
-    <p>Temporary: <a href="/item_search/">Search</a>&nbsp;<a href="/admin/">Admin</a>&nbsp;<a href="/logs/">Logs</a>&nbsp;<a href="/admin/logout/">Logout</a></p>
+    <ul class="navbar">
+        <li><a href="/item_search/">Search (by ARK or Title)</a></li>
+        <li><a href="/admin/">Admin (Metadata Configuration)</a></li>
+        <li><a href="/logs/">Logs</a></li>
+        <li><a href="/admin/logout/">Logout</a></li>
+    </ul>
+    <br>
     {% block content %}
     {% endblock %}
 </body>

--- a/oh_staff_ui/templates/oh_staff_ui/base.html
+++ b/oh_staff_ui/templates/oh_staff_ui/base.html
@@ -13,6 +13,7 @@
 <body>
     <ul class="navbar">
         <li><a href="/item_search/">Search (by ARK or Title)</a></li>
+        <li><a href="/add_item/">Add Item</a></li>
         <li><a href="/admin/">Admin (Metadata Configuration)</a></li>
         <li><a href="/logs/">Logs</a></li>
         <li><a href="/admin/logout/">Logout</a></li>

--- a/oh_staff_ui/urls.py
+++ b/oh_staff_ui/urls.py
@@ -5,7 +5,7 @@ urlpatterns = [
     path("add_item/", views.add_item, name="add_item"),
     path("add_item/<int:parent_id>", views.add_item, name="add_item_from_parent"),
     path("item/<int:item_id>", views.edit_item, name="edit_item"),
-    path("", views.add_item),  # TODO: Change this to something better.....
+    path("", views.item_search),
     path("item_search/", views.item_search, name="item_search"),
     path(
         "search_results/<str:search_type>/<path:query>",

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1,3 +1,27 @@
+ul.navbar {
+    list-style-type: none;
+    margin: 0;
+    padding: 0;
+    overflow: hidden;
+    background-color: #d0d0d7;
+    border: 1px solid black;
+}
+  
+.navbar li {
+    float: left;
+    border-right: 1px solid #bcbcc5;
+}
+  
+.navbar li a {
+    display: block;
+    text-align: center;
+    padding: 10px 12px;
+    text-decoration: none;
+    color: #0000ee;
+}
+
+
+
 .search-results {
    width: 100%;
 }

--- a/templates/admin/base_site.html
+++ b/templates/admin/base_site.html
@@ -1,0 +1,9 @@
+{% extends "admin/base.html" %}
+
+{% block title %}Oral History Admin{% endblock %}
+
+{% block branding %}
+<h1 id="site-name"><a href="{% url 'admin:index' %}">Oral History Administration</a></h1>
+{% endblock %}
+
+{% block nav-global %}<a href="{{ site_url }}">Main Oral History Staff Interface</a>{% endblock %}


### PR DESCRIPTION
Implements [SYS-1241](https://jira.library.ucla.edu/browse/SYS-1241)

This PR styles the menu links on each page of the site as a navbar, and adds an additional link from the admin interface to the main site. I'd particularly appreciate feedback about the wording of the links - right now I'm using "Admin (Metadata Configuration)" to link to the admin interface, and "Main Oral History Staff Interface" to link back to the main site. 

Also, there is a preexisting link to the site in the admin interface header ("view site"). I think it's useful to have the link displayed more prominently and with better wording even if it's redundant, but let me know if I should remove the old one. 

Main site header:
<img width="619" alt="image" src="https://user-images.githubusercontent.com/7283991/234997713-26a264a8-7659-428f-8c3a-865d2759b1f1.png">
Admin header:
<img width="1419" alt="image" src="https://user-images.githubusercontent.com/7283991/234997788-f3adf6a9-9db0-438a-b1e2-73157cf07d56.png">
