### PR TITLE
SYS-1256: Item type cleanup

### DIFF
--- a/charts/prod-ohstaff-values.yaml
+++ b/charts/prod-ohstaff-values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: uclalibrary/oral-history-staff-ui
-  tag: v0.7.0
+  tag: v0.7.5
   pullPolicy: Always
 
 nameOverride: ""

--- a/oh_staff_ui/fixtures/item-type-data.json
+++ b/oh_staff_ui/fixtures/item-type-data.json
@@ -1,18 +1,10 @@
 [
     {
         "model": "oh_staff_ui.ItemType",
-        "pk": 1,
-        "fields": {
-            "type": "Collection",
-            "parent": null
-        }
-    },
-    {
-        "model": "oh_staff_ui.ItemType",
         "pk": 2,
         "fields": {
             "type": "Series",
-            "parent": 1
+            "parent": null
         }
     },
     {

--- a/oh_staff_ui/models.py
+++ b/oh_staff_ui/models.py
@@ -41,12 +41,6 @@ class ItemType(models.Model):
         ]
 
 
-def get_default_type():
-    # Provides default value for new ProjectItem type field.
-    # Caution: Must be updated if this literal value changes.
-    return ItemType.objects.get(type="Audio").id
-
-
 class ProjectItem(models.Model):
     ark = models.CharField(max_length=40, blank=False, null=False)
     coverage = models.CharField(max_length=256, blank=True, null=False, default="")

--- a/oh_staff_ui/templates/oh_staff_ui/edit_item.html
+++ b/oh_staff_ui/templates/oh_staff_ui/edit_item.html
@@ -2,6 +2,14 @@
 
 {% block content %}
 
+{% if messages %}
+<div class="box">
+{% for message in messages %}
+  <div>{{ message }}</div>
+{% endfor %}
+</div>
+{% endif %}
+
 <table class="header-metadata">
     <caption>Item Information</caption>
     <tr>

--- a/oh_staff_ui/tests.py
+++ b/oh_staff_ui/tests.py
@@ -13,6 +13,7 @@ from oh_staff_ui.models import (
     ItemPublisherUsage,
     ItemResourceUsage,
     ItemSubjectUsage,
+    ItemType,
     Language,
     MediaFile,
     MediaFileType,
@@ -44,7 +45,7 @@ class MediaFileTestCase(TestCase):
             created_by=cls.user,
             last_modified_by=cls.user,
             title="Fake title",
-            type_id=1,
+            type=ItemType.objects.get(type="Series"),
         )
         # Get mock request with generic user info for command-line processing.
         cls.mock_request = HttpRequest()
@@ -444,7 +445,7 @@ class MetadataUniquenessTestCase(TestCase):
             created_by=cls.user,
             last_modified_by=cls.user,
             title="Fake title",
-            type_id=1,
+            type=ItemType.objects.get(type="Series"),
         )
 
     def test_name_usage_is_unique(self):
@@ -496,7 +497,7 @@ class MetadataUniquenessTestCase(TestCase):
                 created_by=self.user,
                 last_modified_by=self.user,
                 title="Fake title",
-                type_id=1,
+                type=ItemType.objects.get(type="Series"),
             )
 
     def test_item_count(self):

--- a/oh_staff_ui/views.py
+++ b/oh_staff_ui/views.py
@@ -24,9 +24,14 @@ logger = logging.getLogger(__name__)
 
 
 @login_required
-def add_item(request: HttpRequest, parent_id=None) -> HttpResponse:
+def add_item(request: HttpRequest, parent_id: int | None = None) -> HttpResponse:
+    # Get parent_item for later use.
+    parent_item: ProjectItem = None
+    if parent_id:
+        parent_item = ProjectItem.objects.get(pk=parent_id)
+
     if request.method == "POST":
-        form = ProjectItemForm(request.POST)
+        form = ProjectItemForm(request.POST, parent_item=parent_item)
         if form.is_valid():
             # Minimal data from form;
             # most other fields set by db defaults or web service.
@@ -60,11 +65,12 @@ def add_item(request: HttpRequest, parent_id=None) -> HttpResponse:
                 )
     else:
         if parent_id:
-            parent = ProjectItem.objects.get(id=parent_id)
-            form = ProjectItemForm(initial={"parent": parent})
+            form = ProjectItemForm(
+                initial={"parent": parent_item}, parent_item=parent_item
+            )
         else:
-            form = ProjectItemForm()
-        return render(request, "oh_staff_ui/add_item.html", {"form": form})
+            form = ProjectItemForm(parent_item=parent_item)
+    return render(request, "oh_staff_ui/add_item.html", {"form": form})
 
 
 @login_required

--- a/oh_staff_ui/views.py
+++ b/oh_staff_ui/views.py
@@ -65,6 +65,7 @@ def add_item(request: HttpRequest, parent_id: int | None = None) -> HttpResponse
                 )
     else:
         if parent_id:
+            # TODO: Consider further changes to form to make "initial" unneeded here.
             form = ProjectItemForm(
                 initial={"parent": parent_item}, parent_item=parent_item
             )


### PR DESCRIPTION
Implements [SYS-1256](https://jira.library.ucla.edu/browse/SYS-1256).

This PR makes improvements to item types:
* Remove unused `Collection` type from the `item-type-data` fixture.
* `Series` is now the top-level item type; otherwise, the hierarchy is unchanged.
* Allow only appropriate item types to display via `ProjectItemForm`, used for adding and editing "pure" item data (not the optional metadata).
  * The only item type allowed for top-level items is `Series`
  * The only item type allowed for 2nd-level items is `Interview`
  * The only item types allowed for 3rd-level items are `Audio` and `Video`, with `Audio` as the default
* Removed the now-obsolete `get_default_type()` method, which always set `Audio` on the form.
* Update existing tests to use real `ItemType` objects instead of id numbers.
* Add tests to confirm the new behavior is correct.
* Minor change: Add `messages` display to `edit_item` template, and a success message, for some visual confirmation that data was saved.
* Bump version to `v0.7.5` for deployment.

Technical details:
`ProjectItemForm.type` is a `ModelChoiceField`, which uses a queryset to determine which `ItemType` values appear in the form.  Instead of all values, this is now dynamic based on where the current item (if any) is in the `Series` -> `Interview` -> `A/V file` hierarchy.

This is determined by passing the current item's parent to the form's `__init()__` method.  Since the item submitted via form may not exist yet, if an item is being created rather than edited, the parent (if any) must be used.  A new method on the form, `_get_relevant_item_types()`, implements this:
* If no parent, choices are `Series`
* If parent is `Series`, choices are `Interview`
* If parent is `Interview`, choices are `Audio` and `Video`

`_get_relevant_item_types()` returns a queryset, which is assigned to the form's `type` field.  The initial value for that field is set to the first value in the queryset, to avoid defaulting to `---------------`.

The form must now have `parent_item` passed to it whenever relevant.  Everywhere this happens in `views` and `views_utils` was updated, except for `get_edit_item_context()` which already has `item.parent` data.

Testing:
Restarting is not needed.  That will load the updated item type fixture, but doesn't remove the obsolete `Collection` type.  That doesn't matter, since `Collection` is completely unused.
```
$ docker-compose exec django python manage.py test
... 43 tests, all passing ...
```

To be thorough, I then deleted `Collection` and re-tested:
```
$ docker-compose exec django python manage.py shell
>>> ItemType.objects.get(type="Collection").delete()
(1, {'oh_staff_ui.ItemType': 1})
```
All 43 tests still pass :)
