### PR TITLE
SYS-1248: Validate content type against file type

### DIFF
--- a/oh_staff_ui/classes/OralHistoryFile.py
+++ b/oh_staff_ui/classes/OralHistoryFile.py
@@ -29,6 +29,8 @@ class OralHistoryFile:
         self._item = ProjectItem.objects.get(pk=self._item_id)
         self._content_type = self.get_content_type(self._original_file_name)
         self._target_dir = self.get_target_dir(self._file_use, self._content_type)
+        # Combination validation checks.
+        self._validate_content_type_against_file_type()
 
     @property
     def content_type(self) -> str:
@@ -199,3 +201,16 @@ class OralHistoryFile:
         else:
             original_file_name = self._original_file_name
         return Path(original_file_name).name
+
+    def _validate_content_type_against_file_type(self) -> None:
+        """Validate content type against file type code.
+
+        Raises ValueError if they do not match.
+        """
+        file_type_code = self._file_type.file_code
+        # File type code should always start with the content type:
+        # audio_master, pdf_legal_agreement, image_thumbnail, etc.
+        if not file_type_code.startswith(self._content_type):
+            raise ValueError(
+                f"File/content type mismatch: {file_type_code=}, {self._content_type=}"
+            )

--- a/oh_staff_ui/tests.py
+++ b/oh_staff_ui/tests.py
@@ -374,6 +374,50 @@ class MediaFileTestCase(TestCase):
                 request=self.mock_request,
             )
 
+    def test_content_type_mismatch_audio(self):
+        wrong_file_type = MediaFileType.objects.get(file_code="pdf_master")
+        with self.assertRaises(ValueError):
+            OralHistoryFile(
+                self.item.id,
+                file_name="samples/sample.wav",
+                file_type=wrong_file_type,
+                file_use="master",
+                request=self.mock_request,
+            )
+
+    def test_content_type_mismatch_image(self):
+        wrong_file_type = MediaFileType.objects.get(file_code="pdf_master")
+        with self.assertRaises(ValueError):
+            OralHistoryFile(
+                self.item.id,
+                file_name="samples/sample.tiff",
+                file_type=wrong_file_type,
+                file_use="master",
+                request=self.mock_request,
+            )
+
+    def test_content_type_mismatch_pdf(self):
+        wrong_file_type = MediaFileType.objects.get(file_code="audio_master")
+        with self.assertRaises(ValueError):
+            OralHistoryFile(
+                self.item.id,
+                file_name="samples/sample.pdf",
+                file_type=wrong_file_type,
+                file_use="master",
+                request=self.mock_request,
+            )
+
+    def test_content_type_mismatch_text(self):
+        wrong_file_type = MediaFileType.objects.get(file_code="pdf_master")
+        with self.assertRaises(ValueError):
+            OralHistoryFile(
+                self.item.id,
+                file_name="samples/sample.xml",
+                file_type=wrong_file_type,
+                file_use="master",
+                request=self.mock_request,
+            )
+
     # If the target_dir tests need to run in the test/prod environment,
     # paths will need changing or several environment variables
     # will need to be overridden.


### PR DESCRIPTION
Implements [SYS-1248](https://jira.library.ucla.edu/browse/SYS-1248).

This PR adds an internal method to `OralHistoryFile` which validates the content type against the file type.  If the check fails, a `ValueError` is raised.

Examples:
* Uploading "file.pdf" but selecting "MasterAudio1" should throw an error
* Uploading "file.wav" and selecting "MasterAudio1" should be accepted.

Testing:
4 new tests were added, checking `audio`, `image`, `pdf`, and `text` (content type) input files against a mismatched file type (e.g., `sample.wav` (audio) against `pdf_master` (pdf).
* No restart necessary.
* `$ docker-compose exec django python manage.py test` should show 52 tests, all passing.
* Pick a random item, like http://127.0.0.1:8000/upload_file/7647, and try to upload a similar mismatch.
* Confirm a matching upload does still work.
