### PR TITLE
SYS-1254: Add ability to search / filter admin metadata

### DIFF
--- a/oh_staff_ui/admin.py
+++ b/oh_staff_ui/admin.py
@@ -57,7 +57,7 @@ class Name(admin.ModelAdmin):
     list_display = ("value", "source")
     ordering = ("value", "source")
     search_fields = ("value",)
-    list_filter = ("source",)
+    list_filter = [("source", admin.RelatedOnlyFieldListFilter)]
 
 
 @admin.register(SubjectType)
@@ -71,7 +71,7 @@ class Subject(admin.ModelAdmin):
     list_display = ("value", "source")
     ordering = ("value", "source")
     search_fields = ("value",)
-    list_filter = ("source",)
+    list_filter = [("source", admin.RelatedOnlyFieldListFilter)]
 
 
 @admin.register(AltIdType)

--- a/oh_staff_ui/admin.py
+++ b/oh_staff_ui/admin.py
@@ -56,6 +56,8 @@ class NameType(admin.ModelAdmin):
 class Name(admin.ModelAdmin):
     list_display = ("value", "source")
     ordering = ("value", "source")
+    search_fields = ("value",)
+    list_filter = ("source",)
 
 
 @admin.register(SubjectType)
@@ -68,6 +70,8 @@ class NameType(admin.ModelAdmin):
 class Subject(admin.ModelAdmin):
     list_display = ("value", "source")
     ordering = ("value", "source")
+    search_fields = ("value",)
+    list_filter = ("source",)
 
 
 @admin.register(AltIdType)
@@ -134,5 +138,3 @@ class DateType(admin.ModelAdmin):
 class MediaFileType(admin.ModelAdmin):
     list_display = ("file_type", "file_type_description")
     ordering = ("file_type", "file_type_description")
-    # Don't let users edit the codes.
-    exclude = ["file_code"]

--- a/oh_staff_ui/admin.py
+++ b/oh_staff_ui/admin.py
@@ -138,3 +138,5 @@ class DateType(admin.ModelAdmin):
 class MediaFileType(admin.ModelAdmin):
     list_display = ("file_type", "file_type_description")
     ordering = ("file_type", "file_type_description")
+    # Don't let users edit the codes.
+    exclude = ["file_code"]


### PR DESCRIPTION
Implements [SYS-1254](https://jira.library.ucla.edu/browse/SYS-1254)

This PR adds a search box (by value) and a filter (by source) to Name and Subject in the admin interface. Combining search and filter values works as you'd expect. Filter values are limited to those actually used in the data. Search by Source is not currently supported, but could be added if desired.