### PR TITLE
SYS-1257: Hide metadata fields on file-level items

### DIFF
--- a/oh_staff_ui/templates/oh_staff_ui/edit_item.html
+++ b/oh_staff_ui/templates/oh_staff_ui/edit_item.html
@@ -194,7 +194,7 @@
             <td>Delete? {{ alt_id_formset.empty_form.DELETE }}</td>
         </tr>
         {% for description_form in description_formset %}
-        <tr id = "description_row">
+        <tr class = "description">
             <td>{% if forloop.first %}
                 <button id="description_add" class="add_formset">+</button>&nbsp;Description(s):
                 {% endif %}

--- a/oh_staff_ui/templates/oh_staff_ui/edit_item.html
+++ b/oh_staff_ui/templates/oh_staff_ui/edit_item.html
@@ -70,7 +70,10 @@
     {{ description_formset.management_form }}
     {{ date_formset.management_form }}
     {{ format_formset.management_form }}
-    <table id="formset_table">
+    <table id="formset_table" 
+        {% if item.type.type == "Audio" or item.type.type == "Video" %} class="file_metadata">
+        {% else %} >
+        {% endif %}
         {% for name_form in name_formset %}
         <tr>
             <td>{% if forloop.first %}
@@ -191,7 +194,7 @@
             <td>Delete? {{ alt_id_formset.empty_form.DELETE }}</td>
         </tr>
         {% for description_form in description_formset %}
-        <tr>
+        <tr id = "description_row">
             <td>{% if forloop.first %}
                 <button id="description_add" class="add_formset">+</button>&nbsp;Description(s):
                 {% endif %}

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -69,7 +69,7 @@ td {
     margin-bottom: 3px;
  }
 
-.file_metadata tr:not([id="description_row"]) {
+.file_metadata tr:not([class="description"]) {
     display: none;
 }
 

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -69,11 +69,15 @@ td {
     margin-bottom: 3px;
  }
 
+/* .file_metadata: optional metadata on edit_item page
+for Audio and Video items. Hide all table rows other 
+than Description. */ 
 .file_metadata tr:not([class="description"]) {
     display: none;
 }
-
-.file_metadata select option:not([value="3"]){
+/* for file-level metadata, hide all dropdown options
+other than TableOfContents (value = "3") */ 
+.file_metadata .description select option:not([value="3"]){
     display: none;
 }
 

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -69,6 +69,14 @@ td {
     margin-bottom: 3px;
  }
 
+.file_metadata tr:not([id="description_row"]) {
+    display: none;
+}
+
+.file_metadata select option:not([value="3"]){
+    display: none;
+}
+
 .header-metadata{
     border-collapse: collapse;
  }

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -30,6 +30,7 @@ function showEmptyForm(event) {
     // Remove id & class, copied from emptyForm
     newForm.removeAttribute("id");
     newForm.classList.remove("empty_form");
+    newForm.classList.add(metadataType);
     
     // Display the new form immediately before the (hidden) empty form.
     emptyForm.parentNode.insertBefore(newForm, emptyForm);

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -30,6 +30,8 @@ function showEmptyForm(event) {
     // Remove id & class, copied from emptyForm
     newForm.removeAttribute("id");
     newForm.classList.remove("empty_form");
+    // add a new class with name of metadataType
+    // used to prevent hiding new Description rows on file-level items
     newForm.classList.add(metadataType);
     
     // Display the new form immediately before the (hidden) empty form.


### PR DESCRIPTION
Implements [SYS-1257](https://jira.library.ucla.edu/browse/SYS-1257)

This PR hides all optional metadata fields other than Description on Audio/Video ProjectItems. In addition, the only visible qualifier is TableOfContents. Styling is done with CSS, with accompanying changes to the template and JS to add class values. 

One question: should adding multiple Descriptions on file-level items be supported? This is possible for now (though all must be TableOfContents), but we could also hide the plus button.