### PR TITLE
Initial add of MODS export libraries and tests

### DIFF
--- a/oh_staff_ui/classes/OralHistoryMods.py
+++ b/oh_staff_ui/classes/OralHistoryMods.py
@@ -1,0 +1,11 @@
+from eulxml.xmlmap.mods import MODS
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class OralHistoryMods(MODS):
+    def __init__(self, ark):
+        super().__init__()
+        self._ark = ark

--- a/oh_staff_ui/tests.py
+++ b/oh_staff_ui/tests.py
@@ -737,6 +737,48 @@ class ProjectItemFormTestCase(TestCase):
         # Check that form validation succeeded.
         self.assertEquals({}, form.errors)
 
+
+class ModsTestCase(TestCase):
+    # MODS related tests require an item of each type to confirm proper record creation,
+    # each has a slightly different field structure in the MODS record
+
+    # Load the lookup tables needed for these tests.
+    fixtures = [
+        "item-status-data.json",
+        "item-type-data.json",
+    ]
+
+    @classmethod
+    def setUpTestData(cls):
+        # Use QAD data for fake user and fake items.
+        cls.user = User.objects.create_user("tester")
+        # Level 1: Series.
+        cls.series_item = ProjectItem.objects.create(
+            ark="fake/abcdef",
+            created_by=cls.user,
+            last_modified_by=cls.user,
+            title="Fake series",
+            type=ItemType.objects.get(type="Series"),
+        )
+        # Level 2: Interview, child of series.
+        cls.interview_item = ProjectItem.objects.create(
+            ark="fake/abcdef",
+            created_by=cls.user,
+            last_modified_by=cls.user,
+            title="Fake interview",
+            type=ItemType.objects.get(type="Interview"),
+            parent=cls.series_item,
+        )
+        # Level 3: Audio, child of interview.
+        cls.audio_item = ProjectItem.objects.create(
+            ark="fake/abcdef",
+            created_by=cls.user,
+            last_modified_by=cls.user,
+            title="Fake audio",
+            type=ItemType.objects.get(type="Audio"),
+            parent=cls.interview_item,
+        )
+
     def test_valid_series_item_mods(self):
         item = self.series_item
         ohmods = OralHistoryMods(item.ark)

--- a/oh_staff_ui/tests.py
+++ b/oh_staff_ui/tests.py
@@ -30,6 +30,8 @@ from oh_staff_ui.models import (
 
 from oh_staff_ui.classes.OralHistoryFile import OralHistoryFile
 from oh_staff_ui.classes.AudioFileHandler import AudioFileHandler
+from oh_staff_ui.classes.OralHistoryMods import OralHistoryMods
+
 
 logger = logging.getLogger(__name__)
 
@@ -734,3 +736,24 @@ class ProjectItemFormTestCase(TestCase):
         form = ProjectItemForm(request.POST, parent_item=self.series_item)
         # Check that form validation succeeded.
         self.assertEquals({}, form.errors)
+
+    def test_valid_series_item_mods(self):
+        item = self.series_item
+        ohmods = OralHistoryMods(item.ark)
+        ohmods.title = item.title
+
+        self.assertEqual(ohmods.is_valid(), True)
+
+    def test_valid_interview_item_mods(self):
+        item = self.interview_item
+        ohmods = OralHistoryMods(item.ark)
+        ohmods.title = item.title
+
+        self.assertEqual(ohmods.is_valid(), True)
+
+    def test_valid_audio_item_mods(self):
+        item = self.audio_item
+        ohmods = OralHistoryMods(item.ark)
+        ohmods.title = item.title
+
+        self.assertEqual(ohmods.is_valid(), True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ whitenoise == 6.0.0
 requests == 2.28.2
 pillow == 9.5.0
 ffmpeg-python == 0.2.0
+eulxml == 1.1.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ requests == 2.28.2
 pillow == 9.5.0
 ffmpeg-python == 0.2.0
 eulxml == 1.1.3
+ply == 3.11


### PR DESCRIPTION
Very basic PR to confirm install and base behavior

- [eulxml](https://eulxml.readthedocs.io/) added to requirements.txt
- `OralHistoryMods` class added extending base `eulxml.xmlmap.mods.MODS` class
- Tests added to validate empty MODS records pass for each item type

This PR is primarily to confirm libraries are installed and able to be tested properly.

To confirm run:
`docker-compose exec django python manage.py test`

All tests should pass if the `eulxml` library is properly installed and a valid empty MODS record can be created for each item type. Jira ticket will be updated to reflect the stripped down PR.

For now the version of eulxml is `1.1.3` rather than the most recent github commit, to be revised if required.
ply version `3.11` added to resolve warning.

