### PR TITLE
SYS-1273: 

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -47,7 +47,7 @@ function disable_upload_button(form) {
 	btn.disabled = true;
 }
 
-if (window.location.href.includes("item_search")) {
+if (document.getElementById("item_search")) {
     // Hide Status field label by default since Title is default search type
     labels = document.getElementsByTagName("label");
     for (let i = 0; i < labels.length; i++) {


### PR DESCRIPTION
Implements [SYS-1273](https://jira.library.ucla.edu/browse/SYS-1273)

Instead of checking that the current page's URL contains "item_search" (which missed the home page search form), `main.js` now checks for the existence of the item_search form before executing the code specific to this page. This fixes the duplicated "Query:" label, and Status search now works directly from the homepage.