### PR TITLE
Adding ark as identifier to MODS record

### DIFF
--- a/oh_staff_ui/classes/OralHistoryMods.py
+++ b/oh_staff_ui/classes/OralHistoryMods.py
@@ -1,11 +1,19 @@
+from eulxml.xmlmap import mods
 from eulxml.xmlmap.mods import MODS
-
+from oh_staff_ui.models import ProjectItem
 import logging
 
 logger = logging.getLogger(__name__)
 
 
 class OralHistoryMods(MODS):
-    def __init__(self, ark):
+    def __init__(self, project_item):
         super().__init__()
-        self._ark = ark
+        self._item = project_item
+
+    def populate_fields(self):
+        self.title = self._item.title
+        self._populate_identifier()
+
+    def _populate_identifier(self):
+        self.identifiers.extend([mods.Identifier(text=self._item.ark)])

--- a/oh_staff_ui/tests.py
+++ b/oh_staff_ui/tests.py
@@ -831,21 +831,21 @@ class ModsTestCase(TestCase):
 
     def test_valid_series_item_mods(self):
         item = self.series_item
-        ohmods = OralHistoryMods(item.ark)
-        ohmods.title = item.title
+        ohmods = OralHistoryMods(item)
+        ohmods.populate_fields()
 
         self.assertEqual(ohmods.is_valid(), True)
 
     def test_valid_interview_item_mods(self):
         item = self.interview_item
-        ohmods = OralHistoryMods(item.ark)
-        ohmods.title = item.title
+        ohmods = OralHistoryMods(item)
+        ohmods.populate_fields()
 
         self.assertEqual(ohmods.is_valid(), True)
 
     def test_valid_audio_item_mods(self):
         item = self.audio_item
-        ohmods = OralHistoryMods(item.ark)
-        ohmods.title = item.title
+        ohmods = OralHistoryMods(item)
+        ohmods.populate_fields()
 
         self.assertEqual(ohmods.is_valid(), True)


### PR DESCRIPTION
Basic PR to rework some tests and add an ARK as an identifier field in a MODS record

Some very slight changes to OralHistoryMods class
- Constructor accepts `ProjectItem` record rather than an id
- `populate_fields` public function intended to house each function to populate a field
- `_populate_identifier` private function that other MODS fields will follow a similar pattern
- Tests updated to reflect constructor changes

This PR is basic to get template ironed out, the remainder of fields will follow a similar pattern, a private function that performs any logic required to populate that particular MODS field, then added to the `populate_fields` function with related tests.