### PR TITLE
SYS-1263: Hide Parent drop-down on add_item form page

### DIFF
--- a/oh_staff_ui/forms.py
+++ b/oh_staff_ui/forms.py
@@ -37,6 +37,7 @@ class ProjectItemForm(forms.Form):
         queryset=(
             ProjectItem.objects.filter(type__type__in=["Series", "Interview"])
         ).order_by("title"),
+        widget=forms.Select(attrs={"class": "parent-dropdown"}),
     )
     title = forms.CharField(
         required=True, max_length=256, widget=forms.TextInput(attrs={"size": 140})

--- a/oh_staff_ui/forms.py
+++ b/oh_staff_ui/forms.py
@@ -37,7 +37,6 @@ class ProjectItemForm(forms.Form):
         queryset=(
             ProjectItem.objects.filter(type__type__in=["Series", "Interview"])
         ).order_by("title"),
-        widget=forms.Select(attrs={"class": "parent-dropdown"}),
     )
     title = forms.CharField(
         required=True, max_length=256, widget=forms.TextInput(attrs={"size": 140})

--- a/oh_staff_ui/templates/oh_staff_ui/base.html
+++ b/oh_staff_ui/templates/oh_staff_ui/base.html
@@ -15,7 +15,7 @@
 <body>
     <ul class="navbar">
         <li><a href="/item_search/">Item Search</a></li>
-        <li><a href="/add_item/">Add Item</a></li>
+        <li><a href="/add_item/">Add Series</a></li>
         <li><a href="/admin/">Admin (Metadata Configuration)</a></li>
         <li><a href="/logs/">Logs</a></li>
         <li><a href="/admin/logout/">Logout</a></li>

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -93,7 +93,7 @@ if (document.getElementById("item_search")) {
 // styling for "add item" page
 if (window.location.href.endsWith("add_item/")) {
     // hide parent dropdown
-    document.getElementsByClassName("parent-dropdown")[0].style.display = "none";
+    document.getElementById("id_parent").style.display = "none";
     // find and hide label for parent dropdown
     labels = document.getElementsByTagName("label");
     for (let i = 0; i < labels.length; i++) {

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -90,3 +90,15 @@ if (document.getElementById("item_search")) {
     }
 }
 
+// styling for "add item" page
+if (window.location.href.endsWith("add_item/")) {
+    // hide parent dropdown
+    document.getElementsByClassName("parent-dropdown")[0].style.display = "none";
+    // find and hide label for parent dropdown
+    labels = document.getElementsByTagName("label");
+    for (let i = 0; i < labels.length; i++) {
+        if (labels[i].getAttribute("for") == "id_parent") {
+            labels[i].style.display = "none";
+        }
+    }
+}


### PR DESCRIPTION
Implements [SYS-1263](https://jira.library.ucla.edu/browse/SYS-1263)

Adds a small amount of conditional JS to hide Parent dropdown and label on the base `add_item` page (i.e. for new series creation). Dropdown and label are still visible after following link to add a child item, and on `edit_item` pages. Base template is also updated to change `add_item` link to read "Add Series".