### PR TITLE
Moved MODS title assignment to own function

### DIFF
--- a/oh_staff_ui/classes/OralHistoryMods.py
+++ b/oh_staff_ui/classes/OralHistoryMods.py
@@ -12,8 +12,11 @@ class OralHistoryMods(MODS):
         self._item = project_item
 
     def populate_fields(self):
-        self.title = self._item.title
+        self._populate_title()
         self._populate_identifier()
+
+    def _populate_title(self):
+        self.title = self._item.title
 
     def _populate_identifier(self):
         self.identifiers.extend([mods.Identifier(text=self._item.ark)])


### PR DESCRIPTION
For consistency moved MODS title assignment to own private function in `OralHistoryMods`

No additional requests are required for MODS validation, the existing test suite can be run to verify valid:
`docker-compose exec django python manage.py test` 