### PR TITLE
SYS-1296: Style with Bootstrap 5

### DIFF
--- a/oh_staff_ui/templates/oh_staff_ui/add_item.html
+++ b/oh_staff_ui/templates/oh_staff_ui/add_item.html
@@ -11,10 +11,13 @@
 
 <form name="add_item" id="add_item" method="POST">
     {% csrf_token %}
-    <table>
-        {% bootstrap_form form layout="horizontal" %}
-    </table>
-    <br>
+    {% bootstrap_field form.parent layout="horizontal" %}
+    {% bootstrap_field form.title layout="horizontal" placeholder="" %}
+    {% bootstrap_field form.type layout="horizontal" %}
+    {% bootstrap_field form.sequence layout="horizontal" placeholder="" %}
+    {% bootstrap_field form.coverage layout="horizontal" placeholder="" %}
+    {% bootstrap_field form.relation layout="horizontal" placeholder="" %}
+    {% bootstrap_field form.status layout="horizontal" %}
     {% bootstrap_button button_type="submit" content="Add Item" %}
 </form>
 {% endblock %}

--- a/oh_staff_ui/templates/oh_staff_ui/add_item.html
+++ b/oh_staff_ui/templates/oh_staff_ui/add_item.html
@@ -1,4 +1,7 @@
+
 {% extends 'oh_staff_ui/base.html' %}
+
+{% load django_bootstrap5 %}
 
 {% block content %}
 
@@ -9,9 +12,9 @@
 <form name="add_item" id="add_item" method="POST">
     {% csrf_token %}
     <table>
-        {{ form.as_table }}
+        {% bootstrap_form form layout="horizontal" %}
     </table>
     <br>
-    <button type="submit">Add Item</button>
+    {% bootstrap_button button_type="submit" content="Add Item" %}
 </form>
 {% endblock %}

--- a/oh_staff_ui/templates/oh_staff_ui/base.html
+++ b/oh_staff_ui/templates/oh_staff_ui/base.html
@@ -1,4 +1,7 @@
 {% load static %}
+{% load django_bootstrap5 %}
+{% bootstrap_css %}
+{% bootstrap_javascript %}
 <!DOCTYPE html>
 <html>
 
@@ -21,8 +24,11 @@
         <li><a href="/admin/logout/">Logout</a></li>
     </ul>
     <br>
-    {% block content %}
-    {% endblock %}
+    <div class="container">
+        {% block content %}
+        {% endblock %}
+    </div>
+    
 </body>
 
 </html>

--- a/oh_staff_ui/templates/oh_staff_ui/edit_item.html
+++ b/oh_staff_ui/templates/oh_staff_ui/edit_item.html
@@ -1,4 +1,5 @@
 {% extends 'oh_staff_ui/base.html' %}
+{% load django_bootstrap5 %}
 
 {% block content %}
 
@@ -56,7 +57,7 @@
 <form name="edit_item" onsubmit="return validateEditItemForm()" id="edit_item" method="POST">
     {% csrf_token %}
     <div class="basic_metadata">
-    {{ item_form.as_div }}
+    {% bootstrap_form item_form %}
     </div>
     <br>
     {{ name_formset.management_form }}

--- a/oh_staff_ui/templates/oh_staff_ui/edit_item.html
+++ b/oh_staff_ui/templates/oh_staff_ui/edit_item.html
@@ -11,7 +11,7 @@
 </div>
 {% endif %}
 
-<table class="header-metadata">
+<table class="header-metadata caption-top">
     <caption>Item Information</caption>
     <tr>
         <td>Title</td>
@@ -47,6 +47,7 @@
         </td>
     </tr>
 </table>
+<br>
 <div>
     <p>Item Hierarchy Context (use arrow to expand)</p>
     <ul class="tree">
@@ -57,7 +58,7 @@
 <form name="edit_item" onsubmit="return validateEditItemForm()" id="edit_item" method="POST">
     {% csrf_token %}
     <div class="basic_metadata">
-    {% bootstrap_form item_form %}
+    {% bootstrap_form item_form layout="horizontal" %}
     </div>
     <br>
     {{ name_formset.management_form }}
@@ -71,200 +72,210 @@
     {{ description_formset.management_form }}
     {{ date_formset.management_form }}
     {{ format_formset.management_form }}
+
     <table id="formset_table" 
         {% if item.type.type == "Audio" or item.type.type == "Video" %} class="file_metadata">
         {% else %} >
         {% endif %}
         {% for name_form in name_formset %}
         <tr>
-            <td>{% if forloop.first %}
-                <button id="name_add" class="add_formset">+</button>&nbsp;Name(s):
+            <td class="label">{% if forloop.first %}
+                {% bootstrap_button id="name_add" button_type="button" button_class="btn-primary add_formset" content="+" %}&nbsp;Name(s):
                 {% endif %}
             </td>
-            <td>{{ name_form.usage_id }} {{ name_form.type }}</td>
-            <td>{{ name_form.value }}</td>
-            <td>Delete? {{ name_form.DELETE }}</td>
+            <td class="qualifier">{% bootstrap_field name_form.usage_id %} {% bootstrap_field name_form.type show_label=False %}</td>
+            <td>{% bootstrap_field name_form.value show_label=False %}</td>
+            <td>{% bootstrap_field name_form.DELETE %}</td>
         </tr>
         {% endfor %}
         <tr id="name_empty_form" class="empty_form">
             <td></td>
-            <td>{{ name_formset.empty_form.usage_id }} {{ name_formset.empty_form.type }}</td>
-            <td>{{ name_formset.empty_form.value }}</td>
-            <td>Delete? {{ name_formset.empty_form.DELETE }}</td>
+            <td class="qualifier">{% bootstrap_field name_formset.empty_form.usage_id %} 
+                {% bootstrap_field name_formset.empty_form.type show_label=False %}</td>
+            <td>{% bootstrap_field name_formset.empty_form.value show_label=False %}</td>
+            <td>{% bootstrap_field name_formset.empty_form.DELETE %}</td>
         </tr>
         {% for subject_form in subject_formset %}
         <tr>
-            <td>{% if forloop.first %}
-                <button id="subject_add" class="add_formset">+</button>&nbsp;Subject(s):
+            <td class="label">{% if forloop.first %}
+                {% bootstrap_button id="subject_add" button_type="button" button_class="btn-primary add_formset" content="+" %}&nbsp;Subject(s):
                 {% endif %}
             </td>
-            <td>{{ subject_form.usage_id }} {{ subject_form.type }}</td>
-            <td>{{ subject_form.value }}</td>
-            <td>Delete? {{ subject_form.DELETE }}</td>
+            <td class="qualifier">{% bootstrap_field subject_form.usage_id %} {% bootstrap_field subject_form.type show_label=False %}</td>
+            <td>{% bootstrap_field subject_form.value show_label=False %}</td>
+            <td>{% bootstrap_field subject_form.DELETE %}</td>
         </tr>
         {% endfor %}
         <tr id="subject_empty_form" class="empty_form">
             <td></td>
-            <td>{{ subject_formset.empty_form.usage_id }} {{ subject_formset.empty_form.type }}</td>
-            <td>{{ subject_formset.empty_form.value }}</td>
-            <td>Delete? {{ subject_formset.empty_form.DELETE }}</td>
+            <td class="qualifier">{% bootstrap_field subject_formset.empty_form.usage_id %} 
+                {% bootstrap_field subject_formset.empty_form.type show_label=False %}</td>
+            <td>{% bootstrap_field subject_formset.empty_form.value show_label=False %}</td>
+            <td>{% bootstrap_field subject_formset.empty_form.DELETE %}</td>
         </tr>
         {% for publisher_form in publisher_formset %}
         <tr>
-            <td>{% if forloop.first %}
-                <button id="publisher_add" class="add_formset">+</button>&nbsp;Publisher(s):
+            <td class="label">{% if forloop.first %}
+                {% bootstrap_button id="publisher_add" button_type="button" button_class="btn-primary add_formset" content="+" %}&nbsp;Publisher(s):
                 {% endif %}
             </td>
-            <td>{{ publisher_form.usage_id }} {{ publisher_form.type }}</td>
-            <td>{{ publisher_form.value }}</td>
-            <td>Delete? {{ publisher_form.DELETE }}</td>
+            <td class="qualifier">{% bootstrap_field publisher_form.usage_id %} {% bootstrap_field publisher_form.type show_label=False %}</td>
+            <td>{% bootstrap_field publisher_form.value show_label=False %}</td>
+            <td>{% bootstrap_field publisher_form.DELETE %}</td>
         </tr>
         {% endfor %}
         <tr id="publisher_empty_form" class="empty_form">
             <td></td>
-            <td>{{ publisher_formset.empty_form.usage_id }} {{ publisher_formset.empty_form.type }}</td>
-            <td>{{ publisher_formset.empty_form.value }}</td>
-            <td>Delete? {{ publisher_formset.empty_form.DELETE }}</td>
+            <td class="qualifier">{% bootstrap_field publisher_formset.empty_form.usage_id %} 
+                {% bootstrap_field publisher_formset.empty_form.type show_label=False %}</td>
+            <td>{% bootstrap_field publisher_formset.empty_form.value show_label=False %}</td>
+            <td>{% bootstrap_field publisher_formset.empty_form.DELETE %}</td>
         </tr>
         {% for copyright_form in copyright_formset %}
         <tr>
-            <td>{% if forloop.first %}
-                <button id="copyright_add" class="add_formset">+</button>&nbsp;Copyright(s):
+            <td class="label">{% if forloop.first %}
+                {% bootstrap_button id="copyright_add" button_type="button" button_class="btn-primary add_formset" content="+" %}&nbsp;Copyright(s):
                 {% endif %}
             </td>
-            <td>{{ copyright_form.usage_id }} {{ copyright_form.type }}</td>
-            <td>{{ copyright_form.value }}</td>
-            <td>Delete? {{ copyright_form.DELETE }}</td>
+            <td class="qualifier">{% bootstrap_field copyright_form.usage_id %} {% bootstrap_field copyright_form.type show_label=False %}</td>
+            <td>{% bootstrap_field copyright_form.value show_label=False %}</td>
+            <td>{% bootstrap_field copyright_form.DELETE %}</td>
         </tr>
         {% endfor %}
         <tr id="copyright_empty_form" class="empty_form">
             <td></td>
-            <td>{{ copyright_formset.empty_form.usage_id }} {{ copyright_formset.empty_form.type }}</td>
-            <td>{{ copyright_formset.empty_form.value }}</td>
-            <td>Delete? {{ copyright_formset.empty_form.DELETE }}</td>
+            <td class="qualifier">{% bootstrap_field copyright_formset.empty_form.usage_id %} 
+                {% bootstrap_field copyright_formset.empty_form.type show_label=False %}</td>
+            <td>{% bootstrap_field copyright_formset.empty_form.value show_label=False %}</td>
+            <td>{% bootstrap_field copyright_formset.empty_form.DELETE %}</td>
         </tr>
         {% for resource_form in resource_formset %}
         <tr>
-            <td>{% if forloop.first %}
-                <button id="resource_add" class="add_formset">+</button>&nbsp;Resource(s):
+            <td class="label">{% if forloop.first %}
+                {% bootstrap_button id="resource_add" button_type="button" button_class="btn-primary add_formset" content="+" %}&nbsp;Resource(s):
                 {% endif %}
             </td>
-            <td>{{ resource_form.usage_id }} {{ resource_form.type }}</td>
-            <td>{{ resource_form.value }}</td>
-            <td>Delete? {{ resource_form.DELETE }}</td>
+            <td class="qualifier">{% bootstrap_field resource_form.usage_id %} {% bootstrap_field resource_form.type show_label=False %}</td>
+            <td>{% bootstrap_field resource_form.value show_label=False %}</td>
+            <td>{% bootstrap_field resource_form.DELETE %}</td>
         </tr>
         {% endfor %}
         <tr id="resource_empty_form" class="empty_form">
             <td></td>
-            <td>{{ resource_formset.empty_form.usage_id }} {{ resource_formset.empty_form.type }}</td>
-            <td>{{ resource_formset.empty_form.value }}</td>
-            <td>Delete? {{ resource_formset.empty_form.DELETE }}</td>
+            <td class="qualifier">{% bootstrap_field resource_formset.empty_form.usage_id %} 
+                {% bootstrap_field resource_formset.empty_form.type show_label=False %}</td>
+            <td>{% bootstrap_field resource_formset.empty_form.value show_label=False %}</td>
+            <td>{% bootstrap_field resource_formset.empty_form.DELETE %}</td>
         </tr>
         {% for alt_title_form in alt_title_formset %}
         <tr>
-            <td>{% if forloop.first %}
-                <button id="alt_title_add" class="add_formset">+</button>&nbsp;Alt Title(s):
+            <td class="label">{% if forloop.first %}
+                {% bootstrap_button id="alt_title_add" button_type="button" button_class="btn-primary add_formset" content="+" %}&nbsp;Alt Title(s):
                 {% endif %}
             </td>
-            <td>{{ alt_title_form.usage_id }} {{ alt_title_form.type }}</td>
-            <td>{{ alt_title_form.value }}</td>
-            <td>Delete? {{ alt_title_form.DELETE }}</td>
+            <td class="qualifier">{% bootstrap_field alt_title_form.usage_id %} {% bootstrap_field alt_title_form.type show_label=False %}</td>
+            <td>{% bootstrap_field alt_title_form.value show_label=False %}</td>
+            <td>{% bootstrap_field alt_title_form.DELETE %}</td>
         </tr>
         {% endfor %}
         <tr id="alt_title_empty_form" class="empty_form">
             <td></td>
-            <td>{{ alt_title_formset.empty_form.usage_id }} {{ alt_title_formset.empty_form.type }}</td>
-            <td>{{ alt_title_formset.empty_form.value }}</td>
-            <td>Delete? {{ alt_title_formset.empty_form.DELETE }}</td>
+            <td class="qualifier">{% bootstrap_field alt_title_formset.empty_form.usage_id %} 
+                {% bootstrap_field alt_title_formset.empty_form.type show_label=False %}</td>
+            <td>{% bootstrap_field alt_title_formset.empty_form.value show_label=False %}</td>
+            <td>{% bootstrap_field alt_title_formset.empty_form.DELETE %}</td>
         </tr>
         {% for alt_id_form in alt_id_formset %}
         <tr>
-            <td>{% if forloop.first %}
-                <button id="alt_id_add" class="add_formset">+</button>&nbsp;Alt ID(s):
+            <td class="label">{% if forloop.first %}
+                {% bootstrap_button id="alt_id_add" button_type="button" button_class="btn-primary add_formset" content="+" %}&nbsp;Alt ID(s):
                 {% endif %}
             </td>
-            <td>{{ alt_id_form.usage_id }} {{ alt_id_form.type }}</td>
-            <td>{{ alt_id_form.value }}</td>
-            <td>Delete? {{ alt_id_form.DELETE }}</td>
+            <td class="qualifier">{% bootstrap_field alt_id_form.usage_id %} {% bootstrap_field alt_id_form.type show_label=False %}</td>
+            <td>{% bootstrap_field alt_id_form.value show_label=False %}</td>
+            <td>{% bootstrap_field alt_id_form.DELETE %}</td>
         </tr>
         {% endfor %}
         <tr id="alt_id_empty_form" class="empty_form">
             <td></td>
-            <td>{{ alt_id_formset.empty_form.usage_id }} {{ alt_id_formset.empty_form.type }}</td>
-            <td>{{ alt_id_formset.empty_form.value }}</td>
-            <td>Delete? {{ alt_id_formset.empty_form.DELETE }}</td>
+            <td class="qualifier">{% bootstrap_field alt_id_formset.empty_form.usage_id %} 
+                {% bootstrap_field alt_id_formset.empty_form.type show_label=False %}</td>
+            <td>{% bootstrap_field alt_id_formset.empty_form.value show_label=False %}</td>
+            <td>{% bootstrap_field alt_id_formset.empty_form.DELETE %}</td>
         </tr>
         {% for description_form in description_formset %}
-        <tr class = "description">
-            <td>{% if forloop.first %}
-                <button id="description_add" class="add_formset">+</button>&nbsp;Description(s):
+        <tr class = "description text-nowrap">
+            <td class="label">{% if forloop.first %}
+                {% bootstrap_button id="description_add" button_type="button" button_class="btn-primary add_formset" content="+" %}&nbsp;Description(s):
                 {% endif %}
             </td>
-            <td>{{ description_form.usage_id }} {{ description_form.type }}</td>
-            <td>{{ description_form.value }}</td>
-            <td>Delete? {{ description_form.DELETE }}</td>
+            <td class="qualifier">{% bootstrap_field description_form.usage_id %} {% bootstrap_field description_form.type show_label=False %}</td>
+            <td>{% bootstrap_field description_form.value show_label=False %}</td>
+            <td>{% bootstrap_field description_form.DELETE %}</td>
         </tr>
         {% endfor %}
         <tr id="description_empty_form" class="empty_form">
             <td></td>
-            <td>{{ description_formset.empty_form.usage_id }} {{ description_formset.empty_form.type }}</td>
-            <td>{{ description_formset.empty_form.value }}</td>
-            <td>Delete? {{ description_formset.empty_form.DELETE }}</td>
+            <td class="qualifier">{% bootstrap_field description_formset.empty_form.usage_id %} 
+                {% bootstrap_field description_formset.empty_form.type show_label=False %}</td>
+            <td>{% bootstrap_field description_formset.empty_form.value show_label=False %}</td>
+            <td>{% bootstrap_field description_formset.empty_form.DELETE %}</td>
         </tr>
         {% for date_form in date_formset %}
         <tr>
-            <td>{% if forloop.first %}
-                <button id="date_add" class="add_formset">+</button>&nbsp;Date(s):
+            <td class="label">{% if forloop.first %}
+                {% bootstrap_button id="date_add" button_type="button" button_class="btn-primary add_formset" content="+" %}&nbsp;Date(s):
                 {% endif %}
             </td>
-            <td>{{ date_form.usage_id }} {{ date_form.type }}</td>
-            <td>{{ date_form.value }}</td>
-            <td>Delete? {{ date_form.DELETE }}</td>
+            <td class="qualifier">{% bootstrap_field date_form.usage_id %} {% bootstrap_field date_form.type show_label=False %}</td>
+            <td>{% bootstrap_field date_form.value show_label=False %}</td>
+            <td>{% bootstrap_field date_form.DELETE %}</td>
         </tr>
         {% endfor %}
         <tr id="date_empty_form" class="empty_form">
             <td></td>
-            <td>{{ date_formset.empty_form.usage_id }} {{ date_formset.empty_form.type }}</td>
-            <td>{{ date_formset.empty_form.value }}</td>
-            <td>Delete? {{ date_formset.empty_form.DELETE }}</td>
+            <td class="qualifier">{% bootstrap_field date_formset.empty_form.usage_id %} 
+                {% bootstrap_field date_formset.empty_form.type show_label=False %}</td>
+            <td>{% bootstrap_field date_formset.empty_form.value show_label=False %}</td>
+            <td>{% bootstrap_field date_formset.empty_form.DELETE %}</td>
         </tr>
         {% for format_form in format_formset %}
         <tr>
-            <td>{% if forloop.first %}
-                <button id="format_add" class="add_formset">+</button>&nbsp;Format(s):
+            <td class="label">{% if forloop.first %}
+                {% bootstrap_button id="format_add" button_type="button" button_class="btn-primary add_formset" content="+" %}&nbsp;Format(s):
                 {% endif %}
             </td>
-            <td>{{ format_form.usage_id }}</td>
-            <td>{{ format_form.value }}</td>
-            <td>Delete? {{ format_form.DELETE }}</td>
+            <td>{% bootstrap_field format_form.usage_id %}</td>
+            <td>{% bootstrap_field format_form.value show_label=False %}</td>
+            <td>{% bootstrap_field format_form.DELETE %}</td>
         </tr>
         {% endfor %}
         <tr id="format_empty_form" class="empty_form">
             <td></td>
-            <td>{{ format_formset.empty_form.usage_id }}</td>
-            <td>{{ format_formset.empty_form.value }}</td>
-            <td>Delete? {{ format_formset.empty_form.DELETE }}</td>
+            <td>{% bootstrap_field format_formset.empty_form.usage_id %}</td>
+            <td>{% bootstrap_field format_formset.empty_form.value show_label=False %}</td>
+            <td>{% bootstrap_field format_formset.empty_form.DELETE %}</td>
         </tr>
         {% for language_form in language_formset %}
         <tr>
-            <td>{% if forloop.first %}
-                <button id="language_add" class="add_formset">+</button>&nbsp;Language(s):
+            <td class="label">{% if forloop.first %}
+                {% bootstrap_button id="language_add" button_type="button" button_class="btn-primary add_formset" content="+" %}&nbsp;Language(s):
                 {% endif %}
             </td>
-            <td>{{ language_form.usage_id }}</td>
-            <td>{{ language_form.value }}</td>
-            <td>Delete? {{ language_form.DELETE }}</td>
+            <td>{% bootstrap_field language_form.usage_id %}</td>
+            <td>{% bootstrap_field language_form.value show_label=False %}</td>
+            <td>{% bootstrap_field language_form.DELETE %}</td>
         </tr>
         {% endfor %}
         <tr id="language_empty_form" class="empty_form">
             <td></td>
-            <td>{{ language_formset.empty_form.usage_id }}</td>
-            <td>{{ language_formset.empty_form.value }}</td>
-            <td>Delete? {{ language_formset.empty_form.DELETE }}</td>
+            <td>{% bootstrap_field language_formset.empty_form.usage_id %}</td>
+            <td>{% bootstrap_field language_formset.empty_form.value show_label=False %}</td>
+            <td>{% bootstrap_field language_formset.empty_form.DELETE %}</td>
         </tr>
     </table>
     <br>
-    <button type="submit">Save</button>
+    {% bootstrap_button button_type="submit" content="Save" %}
 </form>
 {% endblock %}
 

--- a/oh_staff_ui/templates/oh_staff_ui/edit_item.html
+++ b/oh_staff_ui/templates/oh_staff_ui/edit_item.html
@@ -58,7 +58,13 @@
 <form name="edit_item" onsubmit="return validateEditItemForm()" id="edit_item" method="POST">
     {% csrf_token %}
     <div class="basic_metadata">
-    {% bootstrap_form item_form layout="horizontal" %}
+        {% bootstrap_field item_form.parent layout="horizontal" %}
+        {% bootstrap_field item_form.title layout="horizontal" placeholder="" %}
+        {% bootstrap_field item_form.type layout="horizontal" %}
+        {% bootstrap_field item_form.sequence layout="horizontal" placeholder="" %}
+        {% bootstrap_field item_form.coverage layout="horizontal" placeholder="" %}
+        {% bootstrap_field item_form.relation layout="horizontal" placeholder="" %}
+        {% bootstrap_field item_form.status layout="horizontal" %}
     </div>
     <br>
     {{ name_formset.management_form }}
@@ -174,7 +180,7 @@
                 {% endif %}
             </td>
             <td class="qualifier">{% bootstrap_field alt_title_form.usage_id %} {% bootstrap_field alt_title_form.type show_label=False %}</td>
-            <td>{% bootstrap_field alt_title_form.value show_label=False %}</td>
+            <td>{% bootstrap_field alt_title_form.value show_label=False placeholder="" %}</td>
             <td>{% bootstrap_field alt_title_form.DELETE %}</td>
         </tr>
         {% endfor %}
@@ -182,7 +188,7 @@
             <td></td>
             <td class="qualifier">{% bootstrap_field alt_title_formset.empty_form.usage_id %} 
                 {% bootstrap_field alt_title_formset.empty_form.type show_label=False %}</td>
-            <td>{% bootstrap_field alt_title_formset.empty_form.value show_label=False %}</td>
+            <td>{% bootstrap_field alt_title_formset.empty_form.value show_label=False placeholder="" %}</td>
             <td>{% bootstrap_field alt_title_formset.empty_form.DELETE %}</td>
         </tr>
         {% for alt_id_form in alt_id_formset %}
@@ -192,7 +198,7 @@
                 {% endif %}
             </td>
             <td class="qualifier">{% bootstrap_field alt_id_form.usage_id %} {% bootstrap_field alt_id_form.type show_label=False %}</td>
-            <td>{% bootstrap_field alt_id_form.value show_label=False %}</td>
+            <td>{% bootstrap_field alt_id_form.value show_label=False placeholder="" %}</td>
             <td>{% bootstrap_field alt_id_form.DELETE %}</td>
         </tr>
         {% endfor %}
@@ -200,7 +206,7 @@
             <td></td>
             <td class="qualifier">{% bootstrap_field alt_id_formset.empty_form.usage_id %} 
                 {% bootstrap_field alt_id_formset.empty_form.type show_label=False %}</td>
-            <td>{% bootstrap_field alt_id_formset.empty_form.value show_label=False %}</td>
+            <td>{% bootstrap_field alt_id_formset.empty_form.value show_label=False placeholder="" %}</td>
             <td>{% bootstrap_field alt_id_formset.empty_form.DELETE %}</td>
         </tr>
         {% for description_form in description_formset %}
@@ -210,7 +216,7 @@
                 {% endif %}
             </td>
             <td class="qualifier">{% bootstrap_field description_form.usage_id %} {% bootstrap_field description_form.type show_label=False %}</td>
-            <td>{% bootstrap_field description_form.value show_label=False %}</td>
+            <td>{% bootstrap_field description_form.value show_label=False placeholder="" %}</td>
             <td>{% bootstrap_field description_form.DELETE %}</td>
         </tr>
         {% endfor %}
@@ -218,7 +224,7 @@
             <td></td>
             <td class="qualifier">{% bootstrap_field description_formset.empty_form.usage_id %} 
                 {% bootstrap_field description_formset.empty_form.type show_label=False %}</td>
-            <td>{% bootstrap_field description_formset.empty_form.value show_label=False %}</td>
+            <td>{% bootstrap_field description_formset.empty_form.value show_label=False placeholder="" %}</td>
             <td>{% bootstrap_field description_formset.empty_form.DELETE %}</td>
         </tr>
         {% for date_form in date_formset %}
@@ -228,7 +234,7 @@
                 {% endif %}
             </td>
             <td class="qualifier">{% bootstrap_field date_form.usage_id %} {% bootstrap_field date_form.type show_label=False %}</td>
-            <td>{% bootstrap_field date_form.value show_label=False %}</td>
+            <td>{% bootstrap_field date_form.value show_label=False placeholder="" %}</td>
             <td>{% bootstrap_field date_form.DELETE %}</td>
         </tr>
         {% endfor %}
@@ -236,7 +242,7 @@
             <td></td>
             <td class="qualifier">{% bootstrap_field date_formset.empty_form.usage_id %} 
                 {% bootstrap_field date_formset.empty_form.type show_label=False %}</td>
-            <td>{% bootstrap_field date_formset.empty_form.value show_label=False %}</td>
+            <td>{% bootstrap_field date_formset.empty_form.value show_label=False placeholder="" %}</td>
             <td>{% bootstrap_field date_formset.empty_form.DELETE %}</td>
         </tr>
         {% for format_form in format_formset %}
@@ -246,14 +252,14 @@
                 {% endif %}
             </td>
             <td>{% bootstrap_field format_form.usage_id %}</td>
-            <td>{% bootstrap_field format_form.value show_label=False %}</td>
+            <td>{% bootstrap_field format_form.value show_label=False placeholder="" %}</td>
             <td>{% bootstrap_field format_form.DELETE %}</td>
         </tr>
         {% endfor %}
         <tr id="format_empty_form" class="empty_form">
             <td></td>
             <td>{% bootstrap_field format_formset.empty_form.usage_id %}</td>
-            <td>{% bootstrap_field format_formset.empty_form.value show_label=False %}</td>
+            <td>{% bootstrap_field format_formset.empty_form.value show_label=False placeholder="" %}</td>
             <td>{% bootstrap_field format_formset.empty_form.DELETE %}</td>
         </tr>
         {% for language_form in language_formset %}

--- a/oh_staff_ui/templates/oh_staff_ui/item_search.html
+++ b/oh_staff_ui/templates/oh_staff_ui/item_search.html
@@ -12,7 +12,6 @@
             <td>{% bootstrap_field form.status_query layout="floating"%}</td>
         </tr>
     </table>
-    <br>
     {% bootstrap_button button_type="submit" content="Search" %}
 </form>
 {% endblock %}

--- a/oh_staff_ui/templates/oh_staff_ui/item_search.html
+++ b/oh_staff_ui/templates/oh_staff_ui/item_search.html
@@ -8,6 +8,6 @@
         {% bootstrap_form form %}
     </table>
     <br>
-    <button type="submit">Search</button>
+    {% bootstrap_button button_type="submit" content="Search" %}
 </form>
 {% endblock %}

--- a/oh_staff_ui/templates/oh_staff_ui/item_search.html
+++ b/oh_staff_ui/templates/oh_staff_ui/item_search.html
@@ -5,7 +5,12 @@
 <form name="item_search" onsubmit ="return validateSearchForm()" id="item_search" method="POST">
     {% csrf_token %}
     <table>
-        {% bootstrap_form form layout="horizontal" %}
+        <tr>
+            <td class="search-type">{% bootstrap_field form.search_type layout="floating" %}</td>
+            <td></td>
+            <td>{% bootstrap_field form.char_query layout="floating" placeholder=""%}</td>
+            <td>{% bootstrap_field form.status_query layout="floating"%}</td>
+        </tr>
     </table>
     <br>
     {% bootstrap_button button_type="submit" content="Search" %}

--- a/oh_staff_ui/templates/oh_staff_ui/item_search.html
+++ b/oh_staff_ui/templates/oh_staff_ui/item_search.html
@@ -5,7 +5,7 @@
 <form name="item_search" onsubmit ="return validateSearchForm()" id="item_search" method="POST">
     {% csrf_token %}
     <table>
-        {% bootstrap_form form %}
+        {% bootstrap_form form layout="horizontal" %}
     </table>
     <br>
     {% bootstrap_button button_type="submit" content="Search" %}

--- a/oh_staff_ui/templates/oh_staff_ui/item_search.html
+++ b/oh_staff_ui/templates/oh_staff_ui/item_search.html
@@ -1,10 +1,11 @@
 {% extends 'oh_staff_ui/base.html' %}
+{% load django_bootstrap5 %}
 
 {% block content %}
 <form name="item_search" onsubmit ="return validateSearchForm()" id="item_search" method="POST">
     {% csrf_token %}
     <table>
-        {{ form.as_table }}
+        {% bootstrap_form form %}
     </table>
     <br>
     <button type="submit">Search</button>

--- a/oh_staff_ui/templates/oh_staff_ui/search_results.html
+++ b/oh_staff_ui/templates/oh_staff_ui/search_results.html
@@ -14,6 +14,7 @@
     </tr>
     {% endfor %}
 </table>
+<br>
 {% else %}
 <p>No results found.</p>
 {% endif %}

--- a/oh_staff_ui/templates/oh_staff_ui/upload_file.html
+++ b/oh_staff_ui/templates/oh_staff_ui/upload_file.html
@@ -70,7 +70,13 @@
 
 <form name="upload_file_form" method="POST" enctype="multipart/form-data" onsubmit="disable_upload_button(this);">
     {% csrf_token %}
-    {% bootstrap_form form layout="horizontal" %}
+    <table>
+      <tr>
+          <td>{% bootstrap_field form.file_type layout="floating" %}</td>
+          <td></td>
+          <td>{% bootstrap_field form.file_name layout="floating" %}</td>
+      </tr>
+  </table>
     {% bootstrap_button button_type="submit" content="Upload" %}
 </form>
 {% endblock %}

--- a/oh_staff_ui/templates/oh_staff_ui/upload_file.html
+++ b/oh_staff_ui/templates/oh_staff_ui/upload_file.html
@@ -61,7 +61,6 @@
 {% endif %}
 <hr>
 {% if messages %}
-<br>
 <div class="box">
 {% for message in messages %}
   <div>{{ message }}</div>

--- a/oh_staff_ui/templates/oh_staff_ui/upload_file.html
+++ b/oh_staff_ui/templates/oh_staff_ui/upload_file.html
@@ -1,7 +1,8 @@
 {% extends 'oh_staff_ui/base.html' %}
+{% load django_bootstrap5 %}
 
 {% block content %}
-<table class="header-metadata">
+<table class="header-metadata caption-top">
   <caption>Item Information</caption>
   <tr>
       <td>Title</td>
@@ -34,10 +35,9 @@
       </td>
   </tr>
 </table>
-<br>
 {% if files %}
 <hr>
-<table class="header-metadata">
+<table class="header-metadata caption-top">
   <caption>File Information</caption>
   <tr>
     <th>File Type</th>
@@ -71,16 +71,7 @@
 
 <form name="upload_file_form" method="POST" enctype="multipart/form-data" onsubmit="disable_upload_button(this);">
     {% csrf_token %}
-    <table>
-      <tr>
-        <td>{{ form.file_type.label }}</td>
-        <td>{{ form.file_name.label }}</td>
-      </tr>
-      <tr>
-        <td>{{ form.file_type }}</td>
-        <td>{{ form.file_name }}</td>
-      </tr>
-    </table>
-    <button type="submit" id="upload_button">Upload</button>
+    {% bootstrap_form form layout="horizontal" %}
+    {% bootstrap_button button_type="submit" content="Upload" %}
 </form>
 {% endblock %}

--- a/project/settings.py
+++ b/project/settings.py
@@ -51,6 +51,7 @@ INSTALLED_APPS = [
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",
+    "django_bootstrap5",
     "oh_staff_ui",
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ pillow == 9.5.0
 ffmpeg-python == 0.2.0
 eulxml == 1.1.3
 ply == 3.11
+django-bootstrap5 == 23.1

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -41,6 +41,10 @@ td.qualifier {
     vertical-align: baseline;
 }
 
+td.qualifier {
+    min-width: 15rem
+}
+
 .empty_form {
     display: none;
 }
@@ -84,6 +88,11 @@ caption {
     --bs-btn-padding-x: 0.5rem;
     --bs-btn-padding-y: 0.1rem;
 }
+
+/* Override bootstrap to reduce vertical space in tall forms*/
+.mb-3 {
+    margin-bottom: .4rem !important;
+  }
 
 /* Workarounds for "bootstrap_form success_css_class" not working  */
 /* CSS class "is-valid" is incorrectly applied to bound forms. */

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -76,12 +76,28 @@ caption {
     color: black;
 }
 
-.form-control,
-.form-select {
-    background-image: none !important;
-}
-
 .add_formset {
     --bs-btn-padding-x: 0.5rem;
     --bs-btn-padding-y: 0.1rem;
+}
+
+/* Workarounds for "bootstrap_form success_css_class" not working  */
+/* CSS class "is-valid" is incorrectly applied to bound forms. */
+/* These four rules remove undesired checkmarks and green border styling. */
+.form-control {
+    background-image: none !important;
+    border-color: var(--bs-border-color) !important;
+}
+/* background-image is caret, copied from regular bootstrap select */
+.form-select.is-valid {
+    background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3e%3cpath fill='none' stroke='%23343a40' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='m2 5 6 6 6-6'/%3e%3c/svg%3e") !important;
+    border-color: var(--bs-border-color) !important;
+}
+
+.form-select.is-valid:focus {
+    box-shadow: 0 0 0 .25rem rgba(13,110,253,.25) !important;
+}
+
+.form-control:focus {
+    box-shadow: 0 0 0 .25rem rgba(13,110,253,.25) !important;
 }

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -20,6 +20,10 @@ ul.navbar {
     text-decoration: none;
 }
 
+td.search-type{
+    min-width: 15rem
+}
+
 .search-results {
    width: 100%;
 }

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -5,6 +5,7 @@ ul.navbar {
     overflow: hidden;
     background-color: #d0d0d7;
     border: 1px solid black;
+    justify-content: unset;
 }
   
 .navbar li {
@@ -17,10 +18,7 @@ ul.navbar {
     text-align: center;
     padding: 10px 12px;
     text-decoration: none;
-    color: #0000ee;
 }
-
-
 
 .search-results {
    width: 100%;

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -32,8 +32,9 @@ ul.navbar {
     font-weight: bold;
 }
 
-td {
-    vertical-align: top;
+td.label,
+td.qualifier {
+    vertical-align: baseline;
 }
 
 .empty_form {
@@ -45,32 +46,10 @@ td {
     padding: 10px;
     border: 1px solid black;
 }
-
- form[name="edit_item"] div {
-     display: table-row;
- }
- 
- form[name="edit_item"] label {
-     display: table-cell;
- }
-
- form[name="edit_item"] select,
- form[name="edit_item"] input,
- form[name="edit_item"] textarea {
-    margin-left: 10px;
-    margin-right: 5px;
- }
-
- form[name="edit_item"] .basic_metadata select,
- form[name="edit_item"] .basic_metadata input,
- form[name="edit_item"] .basic_metadata textarea {
-    margin-bottom: 3px;
- }
-
 /* .file_metadata: optional metadata on edit_item page
 for Audio and Video items. Hide all table rows other 
 than Description. */ 
-.file_metadata tr:not([class="description"]) {
+table.file_metadata tr:not([class*="description"]) {
     display: none;
 }
 /* for file-level metadata, hide all dropdown options
@@ -82,6 +61,7 @@ other than TableOfContents (value = "3") */
 .header-metadata{
     border-collapse: collapse;
  }
+ 
 .header-metadata td{
     padding: 4px;
     border: 1px solid;
@@ -93,15 +73,15 @@ ul.tree {
 
 caption {
     font-weight: bold;
-}
-
-form select,
-form input,
-form textarea {
-    font-family: Helvetica, Arial, sans-serif;
-    font-size: 13.333px;
-}
-
-caption {
     color: black;
+}
+
+.form-control,
+.form-select {
+    background-image: none !important;
+}
+
+.add_formset {
+    --bs-btn-padding-x: 0.5rem;
+    --bs-btn-padding-y: 0.1rem;
 }

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -101,3 +101,7 @@ form textarea {
     font-family: Helvetica, Arial, sans-serif;
     font-size: 13.333px;
 }
+
+caption {
+    color: black;
+}


### PR DESCRIPTION
Implements [SYS-1296](https://jira.library.ucla.edu/browse/SYS-1269)

Applies Bootstrap styling to the OH Staff UI application using `django-bootstrap5`. To test, restart your Django container to install the new package requirement, then marvel at the new post-Y2K-looking site. Please test both appearance and functionality, as many of the changes interact with our JS.

The styling is largely default Bootstrap, so there is room for improvement. I have a couple of questions here:
* Form fields are larger and more spaced out now. This is probably easier to read, but also means more scrolling for long `edit_item` pages. Should we try reducing the vertical space between form fields?
* Blank text fields now contain placeholder text. I can't tell if the default color of the text is dark enough to potentially cause confusion regarding which fields are filled out. Should we change this to a different color, or remove the placeholders entirely? 




