### PR TITLE
SYS-1281: Add URLs for non-master file access

### DIFF
--- a/charts/prod-ohstaff-values.yaml
+++ b/charts/prod-ohstaff-values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: uclalibrary/oral-history-staff-ui
-  tag: v0.9.1
+  tag: v0.9.2
   pullPolicy: Always
 
 nameOverride: ""

--- a/oh_staff_ui/templates/oh_staff_ui/upload_file.html
+++ b/oh_staff_ui/templates/oh_staff_ui/upload_file.html
@@ -52,7 +52,13 @@
     <td>{{ file.file_type }}</td>
     <td>{{ file.create_date }} by {{ file.created_by }}</td>
     <td>{{ file.original_file_name }}</td>
-    <td>{{ file.file.name }}</td>
+    <td>
+      {% if file.file_url %}
+      <a href="{{ file.file_url }}">{{ file.file_name_only }}</a>
+      {% else %}
+      {{ file.file_name_only }}
+      {% endif %}
+    </td>
     <td>{{ file.file_size|floatformat:"g" }} bytes</td>
     <td>{{ file.sequence }}</td>
   </tr>

--- a/oh_staff_ui/tests.py
+++ b/oh_staff_ui/tests.py
@@ -577,6 +577,73 @@ class MediaFileTestCase(TestCase):
             "media_dev/oh_lz/audio/masters/fake-abcdef-1-master.wav",
         )
 
+    def test_file_url_master_is_empty(self):
+        # Create minimal MediaFile object directly, with realistic file path.
+        # Use valid placeholder name, then update to realistic path, to
+        # work around SuspiciousFileOperation.
+        mf = MediaFile.objects.create(
+            created_by=self.user,
+            file_type=MediaFileType.objects.get(file_code="text_master_transcript"),
+            item=self.item,
+            original_file_name="FAKE",
+            file="placeholder",
+        )
+        # Work around SuspiciousFileOperation
+        mf.file.name = "/media/oh_lz/text/masters/fake-abcdef-1-master.xml"
+        self.assertEqual(mf.file_url, "")
+
+    def test_file_url_audio_submaster(self):
+        # Create minimal MediaFile object directly, with realistic file path.
+        # Use valid placeholder name, then update to realistic path, to
+        # work around SuspiciousFileOperation.
+        mf = MediaFile.objects.create(
+            created_by=self.user,
+            file_type=MediaFileType.objects.get(file_code="audio_submaster"),
+            item=self.item,
+            original_file_name="FAKE",
+            file="placeholder",
+        )
+        mf.file.name = "/media/oh_wowza/audio/submasters/fake-abcdef-1-submaster.mp3"
+        self.assertEqual(
+            mf.file_url,
+            "https://wowza.library.ucla.edu/dlp/definst/mp3:oralhistory/audio/submasters/"
+            "fake-abcdef-1-submaster.mp3/playlist.m3u8",
+        )
+
+    def test_file_url_static_submaster(self):
+        # Create minimal MediaFile object directly, with realistic file path.
+        # Use valid placeholder name, then update to realistic path, to
+        # work around SuspiciousFileOperation.
+        mf = MediaFile.objects.create(
+            created_by=self.user,
+            file_type=MediaFileType.objects.get(file_code="text_master_transcript"),
+            item=self.item,
+            original_file_name="FAKE",
+            file="placeholder",
+        )
+        mf.file.name = "/media/oh_static/text/submasters/fake-abcdef-1-master.xml"
+        self.assertEqual(
+            mf.file_url,
+            "https://static.library.ucla.edu/oralhistory/text/submasters/fake-abcdef-1-master.xml",
+        )
+
+    def test_file_url_static_thumbnail(self):
+        # Create minimal MediaFile object directly, with realistic file path.
+        # Use valid placeholder name, then update to realistic path, to
+        # work around SuspiciousFileOperation.
+        mf = MediaFile.objects.create(
+            created_by=self.user,
+            file_type=MediaFileType.objects.get(file_code="image_thumbnail"),
+            item=self.item,
+            original_file_name="FAKE",
+            file="placeholder",
+        )
+        mf.file.name = "/media/oh_static/nails/fake-abcdef-1-thumbnail.jpg"
+        self.assertEqual(
+            mf.file_url,
+            "https://static.library.ucla.edu/oralhistory/nails/fake-abcdef-1-thumbnail.jpg",
+        )
+
     def tearDown(self):
         # If new files aren't deleted, Django will create next file with random-ish name.
         # Deleting the MediaFile object does *not* automatically delete the file itself.


### PR DESCRIPTION
Implements [SYS-1281](https://jira.library.ucla.edu/browse/SYS-1281).
Bumps version to `v0.9.2` for deployment.

This PR adds a new property on the `MediaFile` model, `file_url`.  This is calculated based on the full path to the file (relative to the container), which is available via `MediaFile.file.name`.  The URL is not stored in the database, and cannot be queried - it's only available via an instance of `MediaFile`.

`MediaFile.file_url` currently is determined only for non-masters, pending policy and technical decisions about future access to master files.  It also has meaning only for production files (whether in production environment, or data loaded in dev environment), since all real files are accessed by separate production web servers.

There's also a new property, `MediaFile.file_name_only`, which provides the bare file name with no path, for display in templates (e.g., `file_name.xml`, not `/long/container-specific/path/to/file_name.xml`).

The `upload_file` template now displays `file_name_only`, hyperlinked if `file_url` has a value.

There are 4 new tests, covering the 3 valid cases (submaster wowza audio, submaster static files (including images), thumbnail images) and 1 invalid / unsupported case (master files).  The tests are a little awkward, as I found that full paths outside of Django's `BASE_DIR` can raise a `SuspiciousFileOperation`... which I'm still investigating, via SYS-1286.

Testing:
There are 62 tests, all passing.
If you have production file data loaded (via a recent nuke rebuild, or via `docker-compose exec django python manage.py import_file_metadata migration_data/file_metadata.tsv`, look at a few items with files and verify the URLs work as expected.
Examples:
* http://127.0.0.1:8000/upload_file/2339 (PDF and images)
* http://127.0.0.1:8000/upload_file/9850 (audio and XML)
