### PR TITLE
SYS-1286: Fix file handling

### DIFF
--- a/.docker-compose_django.env
+++ b/.docker-compose_django.env
@@ -43,5 +43,3 @@ DJANGO_OH_MASTERSLZ=oh_lz
 DJANGO_OH_WOWZA=oh_wowza
 # Static files
 DJANGO_OH_STATIC=oh_static
-# Oral History source files (not used in dev environment)
-DJANGO_OH_LIBPARTNERS=oh_source

--- a/.docker-compose_django.env
+++ b/.docker-compose_django.env
@@ -28,28 +28,20 @@ DJANGO_SUPERUSER_EMAIL=softwaredev-systems@library.ucla.edu
 # URL to ARK minter (PROD)
 DJANGO_ARK_MINTER=http://noid.library.ucla.edu/noidu_zz8+?mint+1
 
-# Directory containing files "uploaded" by staff.
+# Directory containing files to be "uploaded" by staff.
 # Relative path, starting top level of Django project
 DJANGO_OH_FILE_SOURCE=samples
 # Or absolute path, if preferred
 #DJANGO_OH_FILE_SOURCE=/home/django/oral-history-staff-ui/samples
 
-# Use "test" directories?  Was based on DJANGO_RUN_ENV but can't use that
-# when in production on test k8s environment.
-# Use "Yes" and "No" here.
-DJANGO_USE_TEST_DIRS=No
-
-# Various media directories for processed files
-# Relative paths for development, absolute for real mounts
-# Oral History source files
-DJANGO_OH_LIBPARTNERS=media_dev/oh_source
-#DJANGO_OH_LIBPARTNERS=/media/oh_source
+# Where Django looks for uploaded files
+DJANGO_OH_MEDIA_ROOT=/tmp/media_dev
+# Relative paths within oh_media_root, used by Django
 # Masters "shadow landing zone"
-DJANGO_OH_MASTERSLZ=media_dev/oh_lz
-#DJANGO_OH_MASTERSLZ=/media/oh_lz
+DJANGO_OH_MASTERSLZ=oh_lz
 # Wowza
-DJANGO_OH_WOWZA=media_dev/oh_wowza
-#DJANGO_OH_WOWZA=/media/oh_wowza
+DJANGO_OH_WOWZA=oh_wowza
 # Static files
-DJANGO_OH_STATIC=media_dev/oh_static
-#DJANGO_OH_STATIC=/media/oh_static
+DJANGO_OH_STATIC=oh_static
+# Oral History source files (not used in dev environment)
+DJANGO_OH_LIBPARTNERS=oh_source

--- a/README.md
+++ b/README.md
@@ -196,7 +196,8 @@ In deployed container:
 
 ### Testing
 
-Tests focus on code which has significant side effects, like creating & changing files.  Run tests in the container:
+Tests focus on code which has significant side effects, like creating & changing files.  
+Run tests in the container:
 
 ```$ docker-compose exec django python manage.py test```
 
@@ -204,40 +205,59 @@ Tests focus on code which has significant side effects, like creating & changing
 
 In the local development environment, samples files for testing are in the `samples` directory.  This directory and its files are under version control, so only add small files, and be sure any real files have no copyright restrictions.
 
-As files are processed locally, they go into subdirectories of `media_dev`.  The top-level subdirectories are defined via environment variables:
+As files are processed locally, they go into subdirectories of `MEDIA_ROOT` - for developers, `/tmp/media_dev` **in the container**. 
+The top-level subdirectories are defined via environment variables:
 * `DJANGO_OH_MASTERSLZ`
 * `DJANGO_OH_WOWZA`
 * `DJANGO_OH_STATIC`
 
-These directories are under version control, but not any files or subdirectories below the top-level ones.
-```
-media_dev/
-├── oh_lz
-├── oh_static
-└── oh_wowza
-```
-
 Processed files go into various subdirectories below these top-level ones, depending on file use (master, submaster, thumbnail) and content type (audio, image, pdf, text).  Subdirectories are created automatically by Django as needed.
 
-Example, after uploading 1 of each type of master:
+To check the contents of `/tmp/media_dev`, which is only in the container:
 ```
-media_dev/
+# Easiest, but harder to read
+$ docker-compose exec django bash -c "ls -lR /tmp/media_dev"
+
+# Extra step needed after container rebuilds, but easier to read
+# Install tree utility as root (in container):
+$ docker-compose exec -u root django bash -c "apt-get install tree"
+# Then run tree (in container) as normal django user
+$ docker-compose exec django bash -c "tree /tmp/media_dev"
+```
+
+Example, after uploading 1 of each type of file, showing masters and derivatives:
+```
+/tmp/media_dev
 ├── oh_lz
 │   ├── audio
 │   │   └── masters
-│   │       └── 21198-zz000905ms-1-master.wav
+│   │       └── fake-bdef357512-1-master.wav
 │   ├── masters
-│   │   └── 21198-zz000905ms-2-master.tiff
+│   │   └── fake-bdef357512-3-master.tif
 │   ├── pdf
 │   │   └── masters
-│   │       └── 21198-zz000905ms-3-master.pdf
+│   │       └── fake-bdef357512-4-master.pdf
 │   └── text
 │       └── masters
-│           └── 21198-zz000905ms-4-master.xml
+│           └── fake-bdef357512-2-master.xml
 ├── oh_static
+│   ├── nails
+│   │   └── fake-bdef357512-3-thumbnail.jpg
+│   ├── pdf
+│   │   └── submasters
+│   │       └── fake-bdef357512-4-submaster.pdf
+│   ├── submasters
+│   │   └── fake-bdef357512-3-submaster.jpg
+│   └── text
+│       └── submasters
+│           └── fake-bdef357512-2-submaster.xml
 └── oh_wowza
+    └── audio
+        └── submasters
+            └── fake-bdef357512-1-submaster.mp3
+
+18 directories, 9 files
 ```
-TODO: This will be updated once derivative processing is in place.
 
 #### File deletion
 

--- a/charts/Chart.yaml
+++ b/charts/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: "0.1"
 description: Chart for Oral History Staff UI
 name: oh-staff
-version: 0.0.2
+version: 0.0.3

--- a/charts/prod-ohstaff-values.yaml
+++ b/charts/prod-ohstaff-values.yaml
@@ -56,7 +56,6 @@ django:
     # Where Django looks for uploaded files
     oh_media_root: "/media"
     # Relative paths within oh_media_root, used by Django
-    oh_libpartners: "oh_source"
     oh_masterslz: "oh_lz"
     oh_static: "oh_static"
     oh_wowza: "oh_wowza"

--- a/charts/prod-ohstaff-values.yaml
+++ b/charts/prod-ohstaff-values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: uclalibrary/oral-history-staff-ui
-  tag: v0.9.2
+  tag: v0.9.3
   pullPolicy: Always
 
 nameOverride: ""
@@ -53,12 +53,13 @@ django:
     db_user: "oral_history_staff"
     # Specific directory used for source files
     oh_file_source: "/media/oh_source/upload"
-    oh_libpartners: "/media/oh_source"
-    oh_masterslz: "/media/oh_lz"
-    oh_static: "/media/oh_static"
-    oh_wowza: "/media/oh_wowza"
-    # "Yes" or "No"
-    use_test_dirs: "No"
+    # Where Django looks for uploaded files
+    oh_media_root: "/media"
+    # Relative paths within oh_media_root, used by Django
+    oh_libpartners: "oh_source"
+    oh_masterslz: "oh_lz"
+    oh_static: "oh_static"
+    oh_wowza: "oh_wowza"
 
   externalSecrets:
     enabled: "true"

--- a/charts/templates/configmap.yaml
+++ b/charts/templates/configmap.yaml
@@ -18,8 +18,9 @@ data:
   DJANGO_DB_NAME: {{ .Values.django.env.db_name }}
   DJANGO_DB_USER: {{ .Values.django.env.db_user }}
   DJANGO_OH_FILE_SOURCE: {{ .Values.django.env.oh_file_source }}
+  DJANGO_OH_MEDIA_ROOT: {{ .Values.django.env.oh_media_root }}
   DJANGO_OH_LIBPARTNERS: {{ .Values.django.env.oh_libpartners }}
   DJANGO_OH_MASTERSLZ: {{ .Values.django.env.oh_masterslz }}
   DJANGO_OH_STATIC: {{ .Values.django.env.oh_static }}
   DJANGO_OH_WOWZA: {{ .Values.django.env.oh_wowza }}
-  DJANGO_USE_TEST_DIRS: {{ .Values.django.env.use_test_dirs | quote }}
+  

--- a/charts/templates/configmap.yaml
+++ b/charts/templates/configmap.yaml
@@ -19,7 +19,6 @@ data:
   DJANGO_DB_USER: {{ .Values.django.env.db_user }}
   DJANGO_OH_FILE_SOURCE: {{ .Values.django.env.oh_file_source }}
   DJANGO_OH_MEDIA_ROOT: {{ .Values.django.env.oh_media_root }}
-  DJANGO_OH_LIBPARTNERS: {{ .Values.django.env.oh_libpartners }}
   DJANGO_OH_MASTERSLZ: {{ .Values.django.env.oh_masterslz }}
   DJANGO_OH_STATIC: {{ .Values.django.env.oh_static }}
   DJANGO_OH_WOWZA: {{ .Values.django.env.oh_wowza }}

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -48,11 +48,11 @@ django:
     #db_password: ""
     oh_file_source: ""
     target_port: ""
+    oh_media_root: ""
     oh_libpartners: ""
     oh_masterslz: ""
     oh_static: ""
     oh_wowza: ""
-    use_test_dirs: ""
 
   externalSecrets:
     enabled: "false"

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -49,7 +49,6 @@ django:
     oh_file_source: ""
     target_port: ""
     oh_media_root: ""
-    oh_libpartners: ""
     oh_masterslz: ""
     oh_static: ""
     oh_wowza: ""

--- a/media_dev/.gitignore
+++ b/media_dev/.gitignore
@@ -1,8 +1,0 @@
-# Ignore everything in this directory
-*
-# Except this file
-!.gitignore
-# And these subdirectories
-!oh_lz
-!oh_static
-!oh_wowza

--- a/media_dev/oh_lz/.gitignore
+++ b/media_dev/oh_lz/.gitignore
@@ -1,4 +1,0 @@
-# Ignore everything in this directory
-*
-# Except this file
-!.gitignore

--- a/media_dev/oh_static/.gitignore
+++ b/media_dev/oh_static/.gitignore
@@ -1,4 +1,0 @@
-# Ignore everything in this directory
-*
-# Except this file
-!.gitignore

--- a/media_dev/oh_wowza/.gitignore
+++ b/media_dev/oh_wowza/.gitignore
@@ -1,4 +1,0 @@
-# Ignore everything in this directory
-*
-# Except this file
-!.gitignore

--- a/oh_staff_ui/management/commands/import_file_metadata.py
+++ b/oh_staff_ui/management/commands/import_file_metadata.py
@@ -154,10 +154,6 @@ class Command(BaseCommand):
     ) -> str:
         # Combine file name and target dir for full path, with some corrections.
 
-        # Target dir was calculated by OralHistoryFile based on environment;
-        # always use production paths for migrated legacy data.
-        target_dir = target_dir.replace("media_dev", "/media", 1)
-
         # Newer mp3 submasters are in audio/submasters subdirectory, matching target dir;
         # older ones are not, so remove that subdirectory to match.
         if "audio/submasters" not in file_location:

--- a/oh_staff_ui/migrations/0004_mediafile_mediafiletype_and_more.py
+++ b/oh_staff_ui/migrations/0004_mediafile_mediafiletype_and_more.py
@@ -4,7 +4,6 @@ from django.conf import settings
 from django.db import migrations, models
 import django.db.models.deletion
 import django.utils.timezone
-import oh_staff_ui.models
 
 
 class Migration(migrations.Migration):
@@ -29,7 +28,7 @@ class Migration(migrations.Migration):
                 ("create_date", models.DateField(default=django.utils.timezone.now)),
                 (
                     "file",
-                    models.FileField(upload_to=oh_staff_ui.models.get_target_path),
+                    models.FileField(),
                 ),
                 ("sequence", models.IntegerField(default=0)),
             ],

--- a/oh_staff_ui/models.py
+++ b/oh_staff_ui/models.py
@@ -496,13 +496,6 @@ class MediaFileType(models.Model):
         ordering = ["file_type"]
 
 
-def get_target_path(instance, filename):
-    # Determines where a MediaFile.file will be stored.
-    # For now, ignore instance parameter passed in by FileField.
-    # Currently, file_utils.
-    return filename
-
-
 class MediaFile(models.Model):
     created_by = models.ForeignKey(
         settings.AUTH_USER_MODEL,
@@ -512,7 +505,7 @@ class MediaFile(models.Model):
         related_name="+",
     )
     create_date = models.DateTimeField(blank=False, null=False, default=timezone.now)
-    file = models.FileField(upload_to=get_target_path)
+    file = models.FileField()
     # Files, especially masters, may not always be accessible to this application after creation,
     # so we can't rely on getting file size from FileField; capture size on creation.
     file_size = models.PositiveBigIntegerField(null=False, default=0)
@@ -530,7 +523,7 @@ class MediaFile(models.Model):
     def save(self, *args, **kwargs):
         # When files are deleted, self.file.name is already None at this point.
         if self.file.name is not None:
-            new_name = get_target_path(self, self.file.name)
+            new_name = self.file.name
             # Throw an exception if file itself exists, or if there's an object for it already.
             # Check both, since masters could be moved out of local filesystem after a while.
             if Path(new_name).exists() or MediaFile.objects.filter(file=new_name):

--- a/oh_staff_ui/models.py
+++ b/oh_staff_ui/models.py
@@ -546,22 +546,21 @@ class MediaFile(models.Model):
     @property
     def file_url(self) -> str:
         # Calculate URL for a file, based on its path.  URLs are *not* stored in the database.
-        # Only meaningful for production files, which have paths (relative to app container)
-        # starting with /media/.
+        # Only meaningful for production files, not in development environment.
 
         # Skip masters for now, until policy is resolved.
         file_name = self.file.name
         if "/masters/" in file_name:
             file_url = ""
         # Non-audio submasters & thumbnails
-        elif file_name.startswith("/media/oh_static/"):
+        elif file_name.startswith("oh_static/"):
             file_url = file_name.replace(
-                "/media/oh_static/", "https://static.library.ucla.edu/oralhistory/"
+                "oh_static/", "https://static.library.ucla.edu/oralhistory/"
             )
         # Audio submasters
-        elif file_name.startswith("/media/oh_wowza/"):
+        elif file_name.startswith("oh_wowza/"):
             file_url = file_name.replace(
-                "/media/oh_wowza/",
+                "oh_wowza/",
                 "https://wowza.library.ucla.edu/dlp/definst/mp3:oralhistory/",
             )
             file_url += "/playlist.m3u8"

--- a/oh_staff_ui/tests.py
+++ b/oh_staff_ui/tests.py
@@ -592,31 +592,24 @@ class MediaFileTestCase(TestCase):
 
     def test_file_url_master_is_empty(self):
         # Create minimal MediaFile object directly, with realistic file path.
-        # Use valid placeholder name, then update to realistic path, to
-        # work around SuspiciousFileOperation.
         mf = MediaFile.objects.create(
             created_by=self.user,
             file_type=MediaFileType.objects.get(file_code="text_master_transcript"),
             item=self.item,
             original_file_name="FAKE",
-            file="placeholder",
+            file="oh_lz/text/masters/fake-abcdef-1-master.xml",
         )
-        # Work around SuspiciousFileOperation
-        mf.file.name = "/media/oh_lz/text/masters/fake-abcdef-1-master.xml"
         self.assertEqual(mf.file_url, "")
 
     def test_file_url_audio_submaster(self):
         # Create minimal MediaFile object directly, with realistic file path.
-        # Use valid placeholder name, then update to realistic path, to
-        # work around SuspiciousFileOperation.
         mf = MediaFile.objects.create(
             created_by=self.user,
             file_type=MediaFileType.objects.get(file_code="audio_submaster"),
             item=self.item,
             original_file_name="FAKE",
-            file="placeholder",
+            file="oh_wowza/audio/submasters/fake-abcdef-1-submaster.mp3",
         )
-        mf.file.name = "/media/oh_wowza/audio/submasters/fake-abcdef-1-submaster.mp3"
         self.assertEqual(
             mf.file_url,
             "https://wowza.library.ucla.edu/dlp/definst/mp3:oralhistory/audio/submasters/"
@@ -625,16 +618,13 @@ class MediaFileTestCase(TestCase):
 
     def test_file_url_static_submaster(self):
         # Create minimal MediaFile object directly, with realistic file path.
-        # Use valid placeholder name, then update to realistic path, to
-        # work around SuspiciousFileOperation.
         mf = MediaFile.objects.create(
             created_by=self.user,
             file_type=MediaFileType.objects.get(file_code="text_master_transcript"),
             item=self.item,
             original_file_name="FAKE",
-            file="placeholder",
+            file="oh_static/text/submasters/fake-abcdef-1-master.xml",
         )
-        mf.file.name = "/media/oh_static/text/submasters/fake-abcdef-1-master.xml"
         self.assertEqual(
             mf.file_url,
             "https://static.library.ucla.edu/oralhistory/text/submasters/fake-abcdef-1-master.xml",
@@ -642,16 +632,13 @@ class MediaFileTestCase(TestCase):
 
     def test_file_url_static_thumbnail(self):
         # Create minimal MediaFile object directly, with realistic file path.
-        # Use valid placeholder name, then update to realistic path, to
-        # work around SuspiciousFileOperation.
         mf = MediaFile.objects.create(
             created_by=self.user,
             file_type=MediaFileType.objects.get(file_code="image_thumbnail"),
             item=self.item,
             original_file_name="FAKE",
-            file="placeholder",
+            file="oh_static/nails/fake-abcdef-1-thumbnail.jpg",
         )
-        mf.file.name = "/media/oh_static/nails/fake-abcdef-1-thumbnail.jpg"
         self.assertEqual(
             mf.file_url,
             "https://static.library.ucla.edu/oralhistory/nails/fake-abcdef-1-thumbnail.jpg",

--- a/oh_staff_ui/tests.py
+++ b/oh_staff_ui/tests.py
@@ -1,5 +1,6 @@
 import logging
 from pathlib import Path
+from django.conf import settings
 from django.core.files import File
 from django.core.management.base import CommandError
 from django.db import IntegrityError
@@ -62,6 +63,11 @@ class MediaFileTestCase(TestCase):
         cls.mock_request = HttpRequest()
         cls.mock_request.user = User.objects.get(username=cls.user.username)
 
+    def get_full_path(self, relative_path: str) -> Path:
+        # MediaFile.file.name contains a path relative to MEDIA_ROOT;
+        # return the full absolute path.
+        return Path(settings.MEDIA_ROOT, relative_path)
+
     def create_master_audio_file(self):
         # Utility function used in multiple tests.
         file_type = MediaFileType.objects.get(file_code="audio_master")
@@ -117,7 +123,8 @@ class MediaFileTestCase(TestCase):
         handler = AudioFileHandler(master)
         handler.process_files()
         # Confirm the new file exists.
-        self.assertEqual(Path(master.media_file.file.name).exists(), True)
+        new_path = self.get_full_path(master.media_file.file.name)
+        self.assertEqual(new_path.exists(), True)
         # For masters, new file should be same size as original.
         path = Path("samples/sample.wav")
         self.assertEqual(master.media_file.file.size, path.stat().st_size)
@@ -132,10 +139,11 @@ class MediaFileTestCase(TestCase):
         submaster = MediaFile.objects.get(parent=master.media_file)
         self.assertEqual(
             submaster.file.name,
-            "media_dev/oh_wowza/audio/submasters/fake-abcdef-1-submaster.mp3",
+            "oh_wowza/audio/submasters/fake-abcdef-1-submaster.mp3",
         )
         # Confirm the new file itself exists.
-        self.assertEqual(Path(submaster.file.name).exists(), True)
+        new_path = self.get_full_path(submaster.file.name)
+        self.assertEqual(new_path.exists(), True)
         # Confirm we have 2 items, the master and submaster.
         self.assertEqual(MediaFile.objects.count(), 2)
         # Confirm master is parent of submaster.
@@ -155,7 +163,7 @@ class MediaFileTestCase(TestCase):
                 file_type=MediaFileType.objects.get(file_code="audio_master"),
             )
             # Use the filename of the first file for the second file
-            path = Path(file1.media_file.file.name)
+            path = self.get_full_path(file1.media_file.file.name)
             new_name = file1.media_file.file.name
             with path.open(mode="rb") as f:
                 file2.file = File(f, name=new_name)
@@ -184,7 +192,8 @@ class MediaFileTestCase(TestCase):
         handler = ImageFileHandler(master)
         handler.process_files()
         # Confirm the new file exists.
-        self.assertEqual(Path(master.media_file.file.name).exists(), True)
+        new_path = self.get_full_path(master.media_file.file.name)
+        self.assertEqual(new_path.exists(), True)
         # For masters, new file should be same size as original.
         path = Path("samples/sample_marbles.tif")
         self.assertEqual(master.media_file.file.size, path.stat().st_size)
@@ -200,10 +209,11 @@ class MediaFileTestCase(TestCase):
         submaster = MediaFile.objects.get(parent=master.media_file, file_type=file_type)
         self.assertEqual(
             submaster.file.name,
-            "media_dev/oh_static/submasters/fake-abcdef-1-submaster.jpg",
+            "oh_static/submasters/fake-abcdef-1-submaster.jpg",
         )
         # Confirm the new file itself exists.
-        self.assertEqual(Path(submaster.file.name).exists(), True)
+        new_path = self.get_full_path(submaster.file.name)
+        self.assertEqual(new_path.exists(), True)
         # Confirm master is parent of submaster.
         self.assertEqual(master.media_file, submaster.parent)
 
@@ -216,10 +226,11 @@ class MediaFileTestCase(TestCase):
         submaster = MediaFile.objects.get(parent=master.media_file, file_type=file_type)
         self.assertEqual(
             submaster.file.name,
-            "media_dev/oh_static/nails/fake-abcdef-1-thumbnail.jpg",
+            "oh_static/nails/fake-abcdef-1-thumbnail.jpg",
         )
         # Confirm the new file itself exists.
-        self.assertEqual(Path(submaster.file.name).exists(), True)
+        new_path = self.get_full_path(submaster.file.name)
+        self.assertEqual(new_path.exists(), True)
         # Confirm master is parent of submaster.
         self.assertEqual(master.media_file, submaster.parent)
 
@@ -228,7 +239,8 @@ class MediaFileTestCase(TestCase):
         handler = GeneralFileHandler(master)
         handler.process_files()
         # Confirm the new file exists.
-        self.assertEqual(Path(master.media_file.file.name).exists(), True)
+        new_path = self.get_full_path(master.media_file.file.name)
+        self.assertEqual(new_path.exists(), True)
         # For masters, new file should be same size as original.
         path = Path("samples/sample.xml")
         self.assertEqual(master.media_file.file.size, path.stat().st_size)
@@ -243,10 +255,11 @@ class MediaFileTestCase(TestCase):
         submaster = MediaFile.objects.get(parent=master.media_file)
         self.assertEqual(
             submaster.file.name,
-            "media_dev/oh_static/text/submasters/fake-abcdef-1-submaster.xml",
+            "oh_static/text/submasters/fake-abcdef-1-submaster.xml",
         )
         # Confirm the new file itself exists.
-        self.assertEqual(Path(submaster.file.name).exists(), True)
+        new_path = self.get_full_path(submaster.file.name)
+        self.assertEqual(new_path.exists(), True)
         # Confirm we have 2 items, the master and submaster.
         self.assertEqual(MediaFile.objects.count(), 2)
         # Confirm master is parent of submaster.
@@ -442,7 +455,7 @@ class MediaFileTestCase(TestCase):
             file_use="master",
             request=self.mock_request,
         )
-        self.assertEqual(ohf.target_dir, "media_dev/oh_lz/audio/masters")
+        self.assertEqual(ohf.target_dir, "oh_lz/audio/masters")
 
     def test_get_target_dir_submaster_audio(self):
         file_type = MediaFileType.objects.get(file_code="audio_submaster")
@@ -453,7 +466,7 @@ class MediaFileTestCase(TestCase):
             file_use="submaster",
             request=self.mock_request,
         )
-        self.assertEqual(ohf.target_dir, "media_dev/oh_wowza/audio/submasters")
+        self.assertEqual(ohf.target_dir, "oh_wowza/audio/submasters")
 
     def test_get_target_dir_master_image(self):
         file_type = MediaFileType.objects.get(file_code="image_master")
@@ -464,7 +477,7 @@ class MediaFileTestCase(TestCase):
             file_use="master",
             request=self.mock_request,
         )
-        self.assertEqual(ohf.target_dir, "media_dev/oh_lz/masters")
+        self.assertEqual(ohf.target_dir, "oh_lz/masters")
 
     def test_get_target_dir_submaster_image(self):
         file_type = MediaFileType.objects.get(file_code="image_submaster")
@@ -475,7 +488,7 @@ class MediaFileTestCase(TestCase):
             file_use="submaster",
             request=self.mock_request,
         )
-        self.assertEqual(ohf.target_dir, "media_dev/oh_static/submasters")
+        self.assertEqual(ohf.target_dir, "oh_static/submasters")
 
     def test_get_target_dir_thumbnail_image(self):
         file_type = MediaFileType.objects.get(file_code="image_thumbnail")
@@ -486,7 +499,7 @@ class MediaFileTestCase(TestCase):
             file_use="thumbnail",
             request=self.mock_request,
         )
-        self.assertEqual(ohf.target_dir, "media_dev/oh_static/nails")
+        self.assertEqual(ohf.target_dir, "oh_static/nails")
 
     def test_get_target_dir_master_pdf(self):
         file_type = MediaFileType.objects.get(file_code="pdf_master_legal_agreement")
@@ -497,7 +510,7 @@ class MediaFileTestCase(TestCase):
             file_use="master",
             request=self.mock_request,
         )
-        self.assertEqual(ohf.target_dir, "media_dev/oh_lz/pdf/masters")
+        self.assertEqual(ohf.target_dir, "oh_lz/pdf/masters")
 
     def test_get_target_dir_submaster_pdf(self):
         file_type = MediaFileType.objects.get(file_code="pdf_master_legal_agreement")
@@ -508,7 +521,7 @@ class MediaFileTestCase(TestCase):
             file_use="submaster",
             request=self.mock_request,
         )
-        self.assertEqual(ohf.target_dir, "media_dev/oh_static/pdf/submasters")
+        self.assertEqual(ohf.target_dir, "oh_static/pdf/submasters")
 
     def test_get_target_dir_master_text(self):
         file_type = MediaFileType.objects.get(file_code="text_master_transcript")
@@ -519,7 +532,7 @@ class MediaFileTestCase(TestCase):
             file_use="master",
             request=self.mock_request,
         )
-        self.assertEqual(ohf.target_dir, "media_dev/oh_lz/text/masters")
+        self.assertEqual(ohf.target_dir, "oh_lz/text/masters")
 
     def test_get_target_dir_submaster_text(self):
         file_type = MediaFileType.objects.get(file_code="text_master_transcript")
@@ -530,7 +543,7 @@ class MediaFileTestCase(TestCase):
             file_use="submaster",
             request=self.mock_request,
         )
-        self.assertEqual(ohf.target_dir, "media_dev/oh_static/text/submasters")
+        self.assertEqual(ohf.target_dir, "oh_static/text/submasters")
 
     def test_get_target_dir_invalid_audio_thumbnail(self):
         # Audio doesn't have thumbnails
@@ -574,7 +587,7 @@ class MediaFileTestCase(TestCase):
         handler.process_files()
         self.assertEqual(
             master.media_file.file.name,
-            "media_dev/oh_lz/audio/masters/fake-abcdef-1-master.wav",
+            "oh_lz/audio/masters/fake-abcdef-1-master.wav",
         )
 
     def test_file_url_master_is_empty(self):
@@ -927,35 +940,33 @@ class FileMetadataMigrationTestCase(SimpleTestCase):
     def test_get_full_file_name_audio_submaster_newer_file_in_original_name(self):
         # Newer file, subdirectory in file name, should go into audio/submasters
         full_file_name = FileMetadataCommand().get_full_file_name(
-            "media_dev/oh_wowza/audio/submasters",
+            "oh_wowza/audio/submasters",
             "audio/submasters/21198-zz002kpt8t-1-submaster.mp3",
             "https://testing/audio/submasters/21198-zz002kpt8t-1-submaster.mp3/playlist.m3u8",
         )
         self.assertEqual(
             full_file_name,
-            "/media/oh_wowza/audio/submasters/21198-zz002kpt8t-1-submaster.mp3",
+            "oh_wowza/audio/submasters/21198-zz002kpt8t-1-submaster.mp3",
         )
 
     def test_get_full_file_name_audio_submaster_newer_file_not_in_original_name(self):
         # Newer file, no subdirectory in file name, should also go into audio/submasters
         full_file_name = FileMetadataCommand().get_full_file_name(
-            "media_dev/oh_wowza/audio/submasters",
+            "oh_wowza/audio/submasters",
             "21198-zz002kpzdt-2-submaster.mp3",
             "https://testing/oralhistory/audio/submasters/21198-zz002kpzdt-2-submaster.mp3/"
             "playlist.m3u8",
         )
         self.assertEqual(
             full_file_name,
-            "/media/oh_wowza/audio/submasters/21198-zz002kpzdt-2-submaster.mp3",
+            "oh_wowza/audio/submasters/21198-zz002kpzdt-2-submaster.mp3",
         )
 
     def test_get_full_file_name_audio_submaster_older_file(self):
         # Older file, should not go into audio/submasters
         full_file_name = FileMetadataCommand().get_full_file_name(
-            "media_dev/oh_wowza/audio/submasters",
+            "oh_wowza/audio/submasters",
             "21198-zz00094qtd-3-submaster.mp3",
             "https://testing/oralhistory/21198-zz00094qtd-3-submaster.mp3/playlist.m3u8",
         )
-        self.assertEqual(
-            full_file_name, "/media/oh_wowza/21198-zz00094qtd-3-submaster.mp3"
-        )
+        self.assertEqual(full_file_name, "oh_wowza/21198-zz00094qtd-3-submaster.mp3")

--- a/project/settings.py
+++ b/project/settings.py
@@ -196,9 +196,6 @@ MEDIA_ROOT = os.getenv("DJANGO_OH_MEDIA_ROOT")
 # Users select files to upload from here.
 # Values supplied are *relative* to MEDIA_ROOT.
 OH_FILE_SOURCE = os.getenv("DJANGO_OH_FILE_SOURCE")
-# This was added for DLCS phase 1 but not used;
-# TODO: Remove from chart?
-# OH_LIBPARTNERS = os.getenv("DJANGO_OH_LIBPARTNERS")
 # Masters "shadow landing zone"
 OH_MASTERSLZ = os.getenv("DJANGO_OH_MASTERSLZ")
 # Wowza

--- a/project/settings.py
+++ b/project/settings.py
@@ -191,9 +191,10 @@ LOGIN_REDIRECT_URL = "/"
 ARK_MINTER = os.getenv("DJANGO_ARK_MINTER")
 
 # Directories for uploaded files and their derivatives.
-# We're not using MEDIA_ROOT, but specifying directories
-# via environment variables.
-# Users select files to upload from here
+MEDIA_ROOT = os.getenv("DJANGO_OH_MEDIA_ROOT")
+
+# Users select files to upload from here.
+# Values supplied are *relative* to MEDIA_ROOT.
 OH_FILE_SOURCE = os.getenv("DJANGO_OH_FILE_SOURCE")
 # This was added for DLCS phase 1 but not used;
 # TODO: Remove from chart?


### PR DESCRIPTION
Implements [SYS-1286](https://jira.library.ucla.edu/browse/SYS-1286). Bumps version to `v0.9.3` for deployment.

This PR fixes a major bug which prevented file uploads from working in the production environment.  The bug was caused by my misunderstanding of Django's `FileField` and its `upload_to` functionality, along with a significant difference in where uploaded files go, between development and production environments.

I thought that `MediaFile.file(upload_to="/some/absolute/path/to/file")` would (a) work, and (b) mean that Django's `MEDIA_ROOT` didn't need to be defined.  Both were wrong :(

`MEDIA_ROOT` defaults to `''`, meaning the top-level directory in the project.  In the development environment, files were going to `media_dev/` - in the top-level directory - with relative paths like `media_dev/oh_static/etc.`.  This all worked fine.

In production, files need to go into `/media/some/path/etc`, which is outside the Django project.  With the default `MEDIA_ROOT`, this is not allowed, causing a `SuspiciousFileOperation` exception.  And `MediaFile.file(upload_to=` does not accept absolute paths, just relative ones.

So, finally, this PR:
* Sets `MEDIA_ROOT` via environmental variable
  * In production: `/media`
  * In development: `/tmp/media_dev` (outside the project, to better simulate the prod environment)
* Updates related path variables like `OH_STATIC` to be relative, not absolute
* Removes the `get_target_path()` method which `MediaFile.file(upload_to=` was (mis)using
  * This required updating a past migration file to make Django happy; no actual migration is needed
* Removes / simplifies related code which no longer needs to distinguish between dev and prod paths
* Updates all relevant tests
* Removes `OH_LIBPARTNERS` and `USE_TEST_DIRS` variables, not needed in this project
* Removes the local `media_dev` directories, no longer needed
* Updates `README.md` with relevant info on viewing `/tmp/media_dev`, since that's only in the container

Testing:
* Pull and check out this branch, `SYS-1286/fix_upload_error`
* Run `docker_scripts/nuke_dev_db.sh` to clear old data, including incorrect file metadata
* Run tests: `docker-compose exec django python manage.py test`; should be 62 tests, all passing
* Upload a few sample files to confirm that all still works correctly via UI
* Check a few existing items and their files, like http://127.0.0.1:8000/upload_file/823 , to confirm URLs for migrated derivative metadata are correct
