### PR TITLE
SYS-1287: Extend gunicorn worker process timeout

### DIFF
--- a/charts/prod-ohstaff-values.yaml
+++ b/charts/prod-ohstaff-values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: uclalibrary/oral-history-staff-ui
-  tag: v0.9.3
+  tag: v0.9.4
   pullPolicy: Always
 
 nameOverride: ""

--- a/docker_scripts/entrypoint.sh
+++ b/docker_scripts/entrypoint.sh
@@ -41,8 +41,8 @@ else
   # Gunicorn cmd line flags:
   # -w number of gunicorn worker processes
   # -b IPADDR:PORT binding
-  # -t timeout in seconds.  
+  # -t timeout in seconds.  This may need to be large for long-running file conversions, until async is added.
   # --access-logfile where to send HTTP access logs (- is stdout)
-  export GUNICORN_CMD_ARGS="-w 3 -b 0.0.0.0:8000 -t 60 --access-logfile -"
+    export GUNICORN_CMD_ARGS="-w 3 -b 0.0.0.0:8000 -t 600 --access-logfile -"
   gunicorn project.wsgi:application
 fi


### PR DESCRIPTION
Implements [SYS-1287](https://jira.library.ucla.edu/browse/SYS-1287).  Bumps version to `v0.9.4` for deployment.

This PR fixes a problem seen when processing larger audio files, by extending the `gunicorn` worker process timeout from 60 seconds to 600 seconds (10 minutes).

This is intended as a workaround, until proper asynchronous file processing is added.
