### PR TITLE
SYS-1277: Provide appropriate default sequence when adding items

### DIFF
--- a/charts/prod-ohstaff-values.yaml
+++ b/charts/prod-ohstaff-values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: uclalibrary/oral-history-staff-ui
-  tag: v0.9.4
+  tag: v0.9.5
   pullPolicy: Always
 
 nameOverride: ""


### PR DESCRIPTION
Implements [SYS-1277](https://jira.library.ucla.edu/browse/SYS-1277).  Bumps version to `v0.9.5` for deployment.

This PR improves item creation by providing an appropriate default value for sequence, when adding an item via `/add_item/` or `/add_item/<parent_id>`.  Item sequence is a required field, but often not used or desired, so manually providing a default is a nuisance.  Users can accept the default, or change it to another value, as desired.
* If the new item is a Series or Interview, the default is always 1.
* If the new item is a File (Audio or Video), the default is the max sequence used by other child items of the same parent (if any), plus 1.
* When editing an existing item, whatever is already stored in the item sequence field will display, as always.

Testing:
Two new tests were added for this functionality (plus a third, `test_all_setup_items_are_created()`, to confirm the test environment is correct).  All 65 tests should pass.

Manual confirmation:
Create a new Series, then a new Interview below it; default sequence for both should be 1.
Create two new File (audio) items below the Interview.  Default sequence for the first should be 1, for the second should be 2.
