### PR TITLE
Addition of creation date element

### DIFF
--- a/oh_staff_ui/classes/OralHistoryMods.py
+++ b/oh_staff_ui/classes/OralHistoryMods.py
@@ -2,6 +2,7 @@ import logging
 from eulxml.xmlmap import mods
 from eulxml.xmlmap.mods import MODS
 from oh_staff_ui.models import (
+    Date,
     Description,
     ItemLanguageUsage,
     Format,
@@ -24,6 +25,7 @@ class OralHistoryMods(MODS):
         self._populate_language()
         self._populate_format()
         self._populate_description()
+        self._populate_create_date()
 
     def _populate_title(self):
         self.title = self._item.title
@@ -81,3 +83,11 @@ class OralHistoryMods(MODS):
             else:
                 # Remaining 'note' types or non-matching get element with no type
                 self.notes.append(mods.Note(text=desc.value))
+    
+    def _populate_create_date(self):
+        dates = Date.objects.filter(item=self._item, type__type__exact="creation")
+        
+        for date in dates:
+            self.create_origin_info()
+            self.origin_info.created.append(mods.DateCreated(date=date))
+

--- a/oh_staff_ui/classes/OralHistoryMods.py
+++ b/oh_staff_ui/classes/OralHistoryMods.py
@@ -51,7 +51,9 @@ class OralHistoryMods(MODS):
 
     def _populate_description(self):
         # Exclude adminnote and tableOfContents types from query entirely
-        descriptions = Description.objects.filter(item=self._item).exclude(type__type__in=["adminnote", "tableOfContents"]) 
+        descriptions = Description.objects.filter(item=self._item).exclude(
+            type__type__in=["adminnote", "tableOfContents"]
+        )
 
         # Similar note element behaving qualifiers
         type_labels = {
@@ -83,11 +85,10 @@ class OralHistoryMods(MODS):
             else:
                 # Remaining 'note' types or non-matching get element with no type
                 self.notes.append(mods.Note(text=desc.value))
-    
+
     def _populate_create_date(self):
         dates = Date.objects.filter(item=self._item, type__type__exact="creation")
-        
+
         for date in dates:
             self.create_origin_info()
             self.origin_info.created.append(mods.DateCreated(date=date))
-

--- a/oh_staff_ui/tests.py
+++ b/oh_staff_ui/tests.py
@@ -16,6 +16,8 @@ from oh_staff_ui.management.commands.import_file_metadata import (
 )
 from oh_staff_ui.models import (
     Copyright,
+    Date,
+    DateType,
     Description,
     DescriptionType,
     ItemCopyrightUsage,
@@ -918,6 +920,7 @@ class ModsTestCase(TestCase):
         "item-type-data.json",
         "authority-source-data.json",
         "description-type-data.json",
+        "date-type-data.json",
     ]
 
     @classmethod
@@ -977,6 +980,12 @@ class ModsTestCase(TestCase):
             item=cls.interview_item,
             value="Generic note should display",
             type=DescriptionType.objects.get(type="note"),
+        )
+
+        Date.objects.create(
+            item=cls.interview_item,
+            value="2000",
+            type=DateType.objects.get(type="creation"),
         )
 
         # Level 3: Audio, child of interview.
@@ -1053,6 +1062,11 @@ class ModsTestCase(TestCase):
         self.assertFalse(
             b"<mods:note>Admin note should not display</mods:note>" in mods_xml
         )
+        self.assertTrue(
+            b"<mods:dateCreated>2000</mods:dateCreated>" in mods_xml
+        )
+
+        print(ohmods.serializeDocument())
 
 
 class FileMetadataMigrationTestCase(SimpleTestCase):

--- a/oh_staff_ui/tests.py
+++ b/oh_staff_ui/tests.py
@@ -1062,9 +1062,7 @@ class ModsTestCase(TestCase):
         self.assertFalse(
             b"<mods:note>Admin note should not display</mods:note>" in mods_xml
         )
-        self.assertTrue(
-            b"<mods:dateCreated>2000</mods:dateCreated>" in mods_xml
-        )
+        self.assertTrue(b"<mods:dateCreated>2000</mods:dateCreated>" in mods_xml)
 
         print(ohmods.serializeDocument())
 

--- a/oh_staff_ui/tests.py
+++ b/oh_staff_ui/tests.py
@@ -1064,8 +1064,6 @@ class ModsTestCase(TestCase):
         )
         self.assertTrue(b"<mods:dateCreated>2000</mods:dateCreated>" in mods_xml)
 
-        print(ohmods.serializeDocument())
-
 
 class FileMetadataMigrationTestCase(SimpleTestCase):
     # Test logic not already covered by OralHistoryFile tests.


### PR DESCRIPTION
Adding PR for each element going forward, future PRs may reference a previous ticket.

This adds tests and support for `mods:dateCreated`. 

Our existing MODS records generation process only outputs those date fields with the `creation` qualifier, so I am following that pattern here by filtering only on this type.

A test added to confirm the record validates and the correct element is in the xml.

To confirm, run tests to verify basic example.

To verify with similar process as previous MODS pr:

```
>>> from oh_staff_ui.classes.OralHistoryMods import OralHistoryMods
>>> from oh_staff_ui.models import ProjectItem
>>> pi = ProjectItem.objects.get(id=2207)
>>> ohm = OralHistoryMods(pi)
>>> ohm.populate_fields()
>>> ohm.serializeDocument()
b'<?xml version=\'1.0\' encoding=\'UTF-8\'?>\n<mods:mods xmlns:mods="http://www.loc.gov/mods/v3"><mods:titleInfo><mods:title>Interview of Tenzin Kiyosaki</mods:title></mods:titleInfo><mods:identifier>21198/zz002kdzd7</mods:identifier><mods:language><mods:languageTerm>eng</mods:languageTerm></mods:language><mods:physicalDescription><mods:extent>6.5 hrs.</mods:extent></mods:physicalDescription><mods:note type="interviewerhistory" displayLabel="Interviewer Background and Preparation">The interview was conducted by Alex Cline, series coordinator, UCLA Library Center for Oral History Research; musician; member, Order of Interbeing, Plum Village Community of Engaged Buddhism, ordained 2009 by Ven. Thich Nhat Hanh.</mods:note><mods:note type="processinterview" displayLabel="Processing of Interview">The interviewer prepared a timed log of the audio recording of the interview. Kiyosaki was given the opportunity to review the log in order to supply missing or misspelled names and to verify the accuracy of the content but made no changes.</mods:note><mods:note type="personpresent" displayLabel="Persons Present">Kiyosaki and Cline.</mods:note><mods:note type="place" displayLabel="Place Conducted">Kiyosaki\'s home in Gardena, California.</mods:note><mods:note type="supportingdocuments" displayLabel="Supporting Documents">Records relating to the interview are located in the office of the UCLA Library\'s Center for Oral History Research.</mods:note><mods:note type="biographical" displayLabel="Biographical Information">Ordained as a Tibetan Buddhist nun by His Holiness the Dalai Lama in 1985. Visiting teacher at Thubten Dhargye Ling in Long Beach, California.</mods:note><mods:originInfo><mods:dateCreated>2019</mods:dateCreated></mods:originInfo></mods:mods>'
```
beautified:

```
<?xml version=\'1.0\' encoding=\'UTF-8\'?>\n
<mods:mods
	xmlns:mods="http://www.loc.gov/mods/v3">
	<mods:titleInfo>
		<mods:title>Interview of Tenzin Kiyosaki</mods:title>
	</mods:titleInfo>
	<mods:identifier>21198/zz002kdzd7</mods:identifier>
	<mods:language>
		<mods:languageTerm>eng</mods:languageTerm>
	</mods:language>
	<mods:physicalDescription>
		<mods:extent>6.5 hrs.</mods:extent>
	</mods:physicalDescription>
	<mods:note type="interviewerhistory" displayLabel="Interviewer Background and Preparation">The interview was conducted by Alex Cline, series coordinator, UCLA Library Center for Oral History Research; musician; member, Order of Interbeing, Plum Village Community of Engaged Buddhism, ordained 2009 by Ven. Thich Nhat Hanh.</mods:note>
	<mods:note type="processinterview" displayLabel="Processing of Interview">The interviewer prepared a timed log of the audio recording of the interview. Kiyosaki was given the opportunity to review the log in order to supply missing or misspelled names and to verify the accuracy of the content but made no changes.</mods:note>
	<mods:note type="personpresent" displayLabel="Persons Present">Kiyosaki and Cline.</mods:note>
	<mods:note type="place" displayLabel="Place Conducted">Kiyosaki\'s home in Gardena, California.</mods:note>
	<mods:note type="supportingdocuments" displayLabel="Supporting Documents">Records relating to the interview are located in the office of the UCLA Library\'s Center for Oral History Research.</mods:note>
	<mods:note type="biographical" displayLabel="Biographical Information">Ordained as a Tibetan Buddhist nun by His Holiness the Dalai Lama in 1985. Visiting teacher at Thubten Dhargye Ling in Long Beach, California.</mods:note>
	<mods:originInfo>
		<mods:dateCreated>2019</mods:dateCreated>
	</mods:originInfo>
</mods:mods>
```
Verify dateCreated element and value match the [item](http://127.0.0.1:8000/item/2207)
