### PR TITLE
Addition of alternate title mods element

### DIFF
--- a/oh_staff_ui/classes/OralHistoryMods.py
+++ b/oh_staff_ui/classes/OralHistoryMods.py
@@ -2,6 +2,7 @@ import logging
 from eulxml.xmlmap import mods
 from eulxml.xmlmap.mods import MODS
 from oh_staff_ui.models import (
+    AltTitle,
     Date,
     Description,
     ItemLanguageUsage,
@@ -19,6 +20,7 @@ class OralHistoryMods(MODS):
     def populate_fields(self):
         # Elements used in MODS directly on the ProjectItem
         self._populate_title()
+        self._populate_alttitle()
         self._populate_identifier()
         self._populate_relation()
 
@@ -29,6 +31,15 @@ class OralHistoryMods(MODS):
 
     def _populate_title(self):
         self.title = self._item.title
+
+    def _populate_alttitle(self):
+        # All alternate titles are assigned mods type of "alternate", no matter the database assignment
+        self.create_title_info()
+        alt_titles = AltTitle.objects.filter(item=self._item)
+        for alt_title in alt_titles:
+            self.title_info_list.append(
+                mods.TitleInfo(title=alt_title, type="alternative")
+            )
 
     def _populate_identifier(self):
         self.identifiers.extend([mods.Identifier(text=self._item.ark)])

--- a/oh_staff_ui/tests.py
+++ b/oh_staff_ui/tests.py
@@ -15,6 +15,8 @@ from oh_staff_ui.management.commands.import_file_metadata import (
     Command as FileMetadataCommand,
 )
 from oh_staff_ui.models import (
+    AltTitle,
+    AltTitleType,
     Copyright,
     Date,
     DateType,
@@ -921,6 +923,7 @@ class ModsTestCase(TestCase):
         "authority-source-data.json",
         "description-type-data.json",
         "date-type-data.json",
+        "alttitle-type-data.json",
     ]
 
     @classmethod
@@ -986,6 +989,12 @@ class ModsTestCase(TestCase):
             item=cls.interview_item,
             value="2000",
             type=DateType.objects.get(type="creation"),
+        )
+
+        AltTitle.objects.create(
+            item=cls.interview_item,
+            value="Alternate Title",
+            type=AltTitleType.objects.get(type="descriptive"),
         )
 
         # Level 3: Audio, child of interview.
@@ -1059,10 +1068,14 @@ class ModsTestCase(TestCase):
         self.assertTrue(
             b"<mods:note>Generic note should display</mods:note>" in mods_xml
         )
+
         self.assertFalse(
             b"<mods:note>Admin note should not display</mods:note>" in mods_xml
         )
+
         self.assertTrue(b"<mods:dateCreated>2000</mods:dateCreated>" in mods_xml)
+
+        self.assertTrue(b'<mods:titleInfo type="alternative">' in mods_xml)
 
 
 class FileMetadataMigrationTestCase(SimpleTestCase):

--- a/oh_staff_ui/tests.py
+++ b/oh_staff_ui/tests.py
@@ -1011,6 +1011,14 @@ class ModsTestCase(TestCase):
         )
         ItemLanguageUsage.objects.create(item=cls.audio_item, value=language)
 
+    # Utility method to return MODS specific to interview item
+    def get_mods_from_interview_item(self) -> ProjectItem:
+        item = self.interview_item
+        ohmods = OralHistoryMods(item)
+        ohmods.populate_fields()
+
+        return ohmods
+
     def test_valid_series_item_mods(self):
         item = self.series_item
         ohmods = OralHistoryMods(item)
@@ -1019,9 +1027,7 @@ class ModsTestCase(TestCase):
         self.assertEqual(ohmods.is_valid(), True)
 
     def test_valid_interview_item_mods(self):
-        item = self.interview_item
-        ohmods = OralHistoryMods(item)
-        ohmods.populate_fields()
+        ohmods = self.get_mods_from_interview_item()
 
         self.assertEqual(ohmods.is_valid(), True)
 
@@ -1033,9 +1039,7 @@ class ModsTestCase(TestCase):
         self.assertEqual(ohmods.is_valid(), True)
 
     def test_valid_abstract_parse(self):
-        item = self.interview_item
-        ohmods = OralHistoryMods(item)
-        ohmods.populate_fields()
+        ohmods = self.get_mods_from_interview_item()
 
         ohmods_from_string = load_xmlobject_from_string(
             ohmods.serializeDocument(), mods.MODS
@@ -1048,9 +1052,7 @@ class ModsTestCase(TestCase):
         self.assertTrue(b"<mods:abstract>Abstract element</mods:abstract>" in mods_xml)
 
     def test_valid_description_parse(self):
-        item = self.interview_item
-        ohmods = OralHistoryMods(item)
-        ohmods.populate_fields()
+        ohmods = self.get_mods_from_interview_item()
 
         ohmods_from_string = load_xmlobject_from_string(
             ohmods.serializeDocument(), mods.MODS
@@ -1073,9 +1075,19 @@ class ModsTestCase(TestCase):
             b"<mods:note>Admin note should not display</mods:note>" in mods_xml
         )
 
-        self.assertTrue(b"<mods:dateCreated>2000</mods:dateCreated>" in mods_xml)
+    def test_valid_mods_created_date(self):
+        ohmods = self.get_mods_from_interview_item()
+        self.assertEqual(ohmods.is_valid(), True)
+        self.assertTrue(
+            b"<mods:dateCreated>2000</mods:dateCreated>" in ohmods.serializeDocument()
+        )
 
-        self.assertTrue(b'<mods:titleInfo type="alternative">' in mods_xml)
+    def test_valid_mods_alttitle(self):
+        ohmods = self.get_mods_from_interview_item()
+        self.assertEqual(ohmods.is_valid(), True)
+        self.assertTrue(
+            b'<mods:titleInfo type="alternative">' in ohmods.serializeDocument()
+        )
 
 
 class FileMetadataMigrationTestCase(SimpleTestCase):


### PR DESCRIPTION
Addition of AltTitle mods element.

If an AltTitle record is present an additional `mods:titleInfo` field will be created with type of `alternative`.

Testing:

`AltTitle` is not as common as other fields, so a quick way is to edit a record to add an AltTitle with any qualifier, and confirm via shell using similar calls as previous PR.

```
>>> pi = ProjectItem.objects.get(id=2207)
>>> ohm = OralHistoryMods(pi)
>>> ohm.populate_fields()
>>> ohm.serializeDocument()
```
A test has been added to check for the presence of `titleInfo` along with an attribute type `alternative`, different from the standard `title` field.