### PR TITLE
Addition of test and alt identifier mods element

### DIFF
--- a/oh_staff_ui/classes/OralHistoryMods.py
+++ b/oh_staff_ui/classes/OralHistoryMods.py
@@ -3,9 +3,11 @@ from eulxml.xmlmap import mods
 from eulxml.xmlmap.mods import MODS
 from oh_staff_ui.models import (
     AltTitle,
+    AltId,
     Date,
     Description,
     ItemLanguageUsage,
+
     Format,
 )
 
@@ -42,7 +44,13 @@ class OralHistoryMods(MODS):
             )
 
     def _populate_identifier(self):
-        self.identifiers.extend([mods.Identifier(text=self._item.ark)])
+        # Always add Ark as identifier 
+        self.identifiers.append(mods.Identifier(text=self._item.ark))
+        # If we have other AltIds, add with type
+        alt_ids = AltId.objects.filter(item=self._item)
+        for alt_id in alt_ids:
+            self.identifiers.append(mods.Identifier(text=alt_id.value, type=alt_id.type.type))
+
 
     def _populate_relation(self):
         if self._item.relation:

--- a/oh_staff_ui/tests.py
+++ b/oh_staff_ui/tests.py
@@ -15,6 +15,8 @@ from oh_staff_ui.management.commands.import_file_metadata import (
     Command as FileMetadataCommand,
 )
 from oh_staff_ui.models import (
+    AltId,
+    AltIdType,
     AltTitle,
     AltTitleType,
     Copyright,
@@ -924,6 +926,7 @@ class ModsTestCase(TestCase):
         "description-type-data.json",
         "date-type-data.json",
         "alttitle-type-data.json",
+        "altid-type-data.json",
     ]
 
     @classmethod
@@ -995,6 +998,12 @@ class ModsTestCase(TestCase):
             item=cls.interview_item,
             value="Alternate Title",
             type=AltTitleType.objects.get(type="descriptive"),
+        )
+
+        AltId.objects.create(
+            item=cls.interview_item,
+            value="Alt Id",
+            type=AltIdType.objects.get(type="OPAC"),
         )
 
         # Level 3: Audio, child of interview.
@@ -1087,6 +1096,14 @@ class ModsTestCase(TestCase):
         self.assertEqual(ohmods.is_valid(), True)
         self.assertTrue(
             b'<mods:titleInfo type="alternative">' in ohmods.serializeDocument()
+        )
+
+    def test_valid_mods_altid(self):
+        ohmods = self.get_mods_from_interview_item()
+        self.assertEqual(ohmods.is_valid(), True)
+        self.assertTrue(
+            b'<mods:identifier type="OPAC">Alt Id</mods:identifier>'
+            in ohmods.serializeDocument()
         )
 
 


### PR DESCRIPTION
Addition of AltId mods element.

Testing:

Either add alternate id or use an existing record with one, there are a handful with `OPAC` types
Interview of Cecil Talney - `id=1482`, this may not be same in local DB.
```
>>> pi = ProjectItem.objects.get(id=1482)
>>> ohm = OralHistoryMods(pi)
>>> ohm.populate_fields()
>>> ohm.serializeDocument()
```
A test has been added to check for the presence of identifier along with an assigned attribute