### PR TITLE
Addition of mods name element and test

### DIFF
--- a/oh_staff_ui/classes/OralHistoryMods.py
+++ b/oh_staff_ui/classes/OralHistoryMods.py
@@ -9,6 +9,7 @@ from oh_staff_ui.models import (
     Format,
     ItemCopyrightUsage,
     ItemLanguageUsage,
+    ItemNameUsage,
 )
 
 logger = logging.getLogger(__name__)
@@ -27,6 +28,7 @@ class OralHistoryMods(MODS):
         self._populate_format()
         self._populate_identifier()
         self._populate_language()
+        self._populate_name()
         self._populate_relation()
         self._populate_rights()
         self._populate_title()
@@ -58,6 +60,13 @@ class OralHistoryMods(MODS):
             lang = mods.Language()
             lang.terms.append(mods.LanguageTerm(text=ilu.value))
             self.languages.append(lang)
+
+    def _populate_name(self):
+        for inu in ItemNameUsage.objects.filter(item=self._item):
+            name = mods.Name()
+            name.name_parts.append(mods.NamePart(text=inu.value.value))
+            name.roles.append(mods.Role(type="text", text=inu.type.type))
+            self.names.append(name)
 
     def _populate_relation(self):
         if self._item.relation:

--- a/oh_staff_ui/tests.py
+++ b/oh_staff_ui/tests.py
@@ -19,6 +19,7 @@ from oh_staff_ui.models import (
     AltIdType,
     AltTitle,
     AltTitleType,
+    AuthoritySource,
     Copyright,
     CopyrightType,
     Date,
@@ -37,6 +38,7 @@ from oh_staff_ui.models import (
     MediaFile,
     MediaFileType,
     Name,
+    NameType,
     ProjectItem,
     Publisher,
     Resource,
@@ -929,6 +931,7 @@ class ModsTestCase(TestCase):
         "alttitle-type-data.json",
         "altid-type-data.json",
         "copyright-type-data.json",
+        "name-type-data.json",
     ]
 
     @classmethod
@@ -1014,6 +1017,15 @@ class ModsTestCase(TestCase):
             item=cls.interview_item,
             value=cr,
             type=CopyrightType.objects.get(type="copyrightStatus"),
+        )
+
+        name = Name.objects.create(
+            value="Joe Bruin", source=AuthoritySource.objects.get(source="local")
+        )
+        ItemNameUsage.objects.create(
+            item=cls.interview_item,
+            value=name,
+            type=NameType.objects.get(type="interviewer"),
         )
 
         # Level 3: Audio, child of interview.
@@ -1121,6 +1133,16 @@ class ModsTestCase(TestCase):
         self.assertTrue(
             b"<mods:accessCondition>Rights statement</mods:accessCondition>"
             in ohmods.serializeDocument()
+        )
+
+    def test_valid_mods_name(self):
+        ohmods = self.get_mods_from_interview_item()
+        self.assertTrue(
+            b'<mods:roleTerm type="text">interviewer</mods:roleTerm>'
+            in ohmods.serializeDocument()
+        )
+        self.assertTrue(
+            b"<mods:namePart>Joe Bruin</mods:namePart>" in ohmods.serializeDocument()
         )
 
 


### PR DESCRIPTION
Addition of `Name` and related MODS elements and test

To confirm, run tests, which looking for existence of 2 elements that are constructed when adding a name.

Also confirm via an item that the XML is generated correctly for database data. The same item maybe be used as previously.

```
>>> from oh_staff_ui.models import ProjectItem
>>> from oh_staff_ui.classes.OralHistoryMods import OralHistoryMods
>>> pi = ProjectItem.objects.get(id=1482)
>>> ohm = OralHistoryMods(pi)
>>> ohm.populate_fields()
>>> print(ohm.serializeDocument())
b'<?xml version=\'1.0\' encoding=\'UTF-8\'?>\n<mods:mods xmlns:mods="http://www.loc.gov/mods/v3"><mods:titleInfo><mods:title>Interview of Cecil Talney</mods:title></mods:titleInfo><mods:note type="supportingdocuments" displayLabel="Supporting Documents">Records relating to the interview are located in the UCLA Library\'s Center for Oral History Research.</mods:note><mods:identifier>21198/zz00152bbp</mods:identifier><mods:identifier type="OPAC">4433051</mods:identifier><mods:language><mods:languageTerm>eng</mods:languageTerm></mods:language><mods:name><mods:namePart>Talney, Cecil</mods:namePart><mods:role><mods:roleTerm type="text">interviewee</mods:roleTerm></mods:role></mods:name><mods:name><mods:namePart>Greenblatt, Mary Lee</mods:namePart><mods:role><mods:roleTerm type="text">interviewer</mods:roleTerm></mods:role></mods:name><mods:accessCondition>Interviewee Retained Copyright</mods:accessCondition></mods:mods>'
```
XML pretty print:
```
<?xml version=\'1.0\' encoding=\'UTF-8\'?>\n
<mods:mods
	xmlns:mods="http://www.loc.gov/mods/v3">
	<mods:titleInfo>
		<mods:title>Interview of Cecil Talney</mods:title>
	</mods:titleInfo>
	<mods:note type="supportingdocuments" displayLabel="Supporting Documents">Records relating to the interview are located in the UCLA Library\'s Center for Oral History Research.</mods:note>
	<mods:identifier>21198/zz00152bbp</mods:identifier>
	<mods:identifier type="OPAC">4433051</mods:identifier>
	<mods:language>
		<mods:languageTerm>eng</mods:languageTerm>
	</mods:language>
	<mods:name>
		<mods:namePart>Talney, Cecil</mods:namePart>
		<mods:role>
			<mods:roleTerm type="text">interviewee</mods:roleTerm>
		</mods:role>
	</mods:name>
	<mods:name>
		<mods:namePart>Greenblatt, Mary Lee</mods:namePart>
		<mods:role>
			<mods:roleTerm type="text">interviewer</mods:roleTerm>
		</mods:role>
	</mods:name>
	<mods:accessCondition>Interviewee Retained Copyright</mods:accessCondition>
</mods:mods>
```

The relevant elements:
```
	<mods:name>
		<mods:namePart>Talney, Cecil</mods:namePart>
		<mods:role>
			<mods:roleTerm type="text">interviewee</mods:roleTerm>
		</mods:role>
	</mods:name>
	<mods:name>
		<mods:namePart>Greenblatt, Mary Lee</mods:namePart>
		<mods:role>
			<mods:roleTerm type="text">interviewer</mods:roleTerm>
		</mods:role>
	</mods:name>
```
The roleTerm type is always assigned to text following the format of the previous code:
`roleTerm.setType(CodeOrText.TEXT);`
