### PR TITLE
Addition of subject mods element and test

### DIFF
--- a/oh_staff_ui/classes/OralHistoryMods.py
+++ b/oh_staff_ui/classes/OralHistoryMods.py
@@ -10,6 +10,7 @@ from oh_staff_ui.models import (
     ItemCopyrightUsage,
     ItemLanguageUsage,
     ItemNameUsage,
+    ItemSubjectUsage,
 )
 
 logger = logging.getLogger(__name__)
@@ -31,6 +32,7 @@ class OralHistoryMods(MODS):
         self._populate_name()
         self._populate_relation()
         self._populate_rights()
+        self._populate_subjects()
         self._populate_title()
 
     def _populate_title(self):
@@ -76,6 +78,23 @@ class OralHistoryMods(MODS):
         # Following previous MODS generation process, accessRights is used with no type assignment
         for copyright in ItemCopyrightUsage.objects.filter(item=self._item):
             self.access_conditions.append(mods.AccessCondition(text=copyright.value))
+
+    def _populate_subjects(self):
+        subs_to_exclude = [
+            "Arts, Literature, Music, and Film",
+            "Donated Oral Histories",
+            "Latinas and Latinos in Music",
+            "Latinas and Latinos in Politics",
+            "Mexican American Civil Rights",
+        ]
+        for isu in ItemSubjectUsage.objects.filter(item=self._item).exclude(
+            value__value__in=subs_to_exclude
+        ):
+            self.subjects.append(
+                mods.Subject(
+                    authority=isu.value.source.source.lower(), topic=isu.value.value
+                )
+            )
 
     def _populate_format(self):
         format = Format.objects.filter(item=self._item).first()

--- a/oh_staff_ui/tests.py
+++ b/oh_staff_ui/tests.py
@@ -1039,6 +1039,16 @@ class ModsTestCase(TestCase):
             type=SubjectType.objects.get(type="level1"),
         )
 
+        subject = Subject.objects.create(
+            value="Arts, Literature, Music, and Film",
+            source=AuthoritySource.objects.get(source="local"),
+        )
+        ItemSubjectUsage.objects.create(
+            item=cls.interview_item,
+            value=subject,
+            type=SubjectType.objects.get(type="level1"),
+        )
+
         # Level 3: Audio, child of interview.
         cls.audio_item = ProjectItem.objects.create(
             ark="fake/abcdef",
@@ -1163,6 +1173,11 @@ class ModsTestCase(TestCase):
         )
         self.assertTrue(
             b"<mods:topic>Sample Subject</mods:topic>" in ohmods.serializeDocument()
+        )
+        # Confirm one of the excluded subjects is not in the record
+        self.assertTrue(
+            b"<mods:topic>Arts, Literature, Music, and Film</mods:topic>"
+            not in ohmods.serializeDocument()
         )
 
 

--- a/oh_staff_ui/tests.py
+++ b/oh_staff_ui/tests.py
@@ -43,6 +43,7 @@ from oh_staff_ui.models import (
     Publisher,
     Resource,
     Subject,
+    SubjectType,
 )
 
 from oh_staff_ui.classes.OralHistoryFile import OralHistoryFile
@@ -932,6 +933,7 @@ class ModsTestCase(TestCase):
         "altid-type-data.json",
         "copyright-type-data.json",
         "name-type-data.json",
+        "subject-type-data.json",
     ]
 
     @classmethod
@@ -1026,6 +1028,15 @@ class ModsTestCase(TestCase):
             item=cls.interview_item,
             value=name,
             type=NameType.objects.get(type="interviewer"),
+        )
+
+        subject = Subject.objects.create(
+            value="Sample Subject", source=AuthoritySource.objects.get(source="local")
+        )
+        ItemSubjectUsage.objects.create(
+            item=cls.interview_item,
+            value=subject,
+            type=SubjectType.objects.get(type="level1"),
         )
 
         # Level 3: Audio, child of interview.
@@ -1143,6 +1154,15 @@ class ModsTestCase(TestCase):
         )
         self.assertTrue(
             b"<mods:namePart>Joe Bruin</mods:namePart>" in ohmods.serializeDocument()
+        )
+
+    def test_valid_mods_subject(self):
+        ohmods = self.get_mods_from_interview_item()
+        self.assertTrue(
+            b'<mods:subject authority="local">' in ohmods.serializeDocument()
+        )
+        self.assertTrue(
+            b"<mods:topic>Sample Subject</mods:topic>" in ohmods.serializeDocument()
         )
 
 


### PR DESCRIPTION
This adds tests and support for mods:subject and completes generation of non-file elements directly attached to a `ProjectItem` (SYS-1207)

Previous logic had a few quirks:

- An option to exclude subjects that match particular values
- The `AuthoritySource` lowercase is used as the authority
- The qualifier is not used in the output

A test added to confirm the record validates and the correct element is in the xml.

To confirm, run tests to verify basic example.

To verify with similar process as previous MODS pr:

```
>>> from oh_staff_ui.classes.OralHistoryMods import OralHistoryMods
>>> from oh_staff_ui.models import ProjectItem
>>> pi = ProjectItem.objects.get(id=2207)
>>> ohm = OralHistoryMods(pi)
>>> ohm.populate_fields()
>>> ohm.serializeDocment()
>>> print(ohm.serializeDocument())
b'<?xml version=\'1.0\' encoding=\'UTF-8\'?>\n<mods:mods xmlns:mods="http://www.loc.gov/mods/v3"><mods:titleInfo/><mods:titleInfo type="alternative"><mods:title>Interview of Tenzin Kiyosaki</mods:title></mods:titleInfo><mods:originInfo><mods:dateCreated>2019</mods:dateCreated></mods:originInfo><mods:note type="interviewerhistory" displayLabel="Interviewer Background and Preparation">The interview was conducted by Alex Cline, series coordinator, UCLA Library Center for Oral History Research; musician; member, Order of Interbeing, Plum Village Community of Engaged Buddhism, ordained 2009 by Ven. Thich Nhat Hanh.</mods:note><mods:note type="processinterview" displayLabel="Processing of Interview">The interviewer prepared a timed log of the audio recording of the interview. Kiyosaki was given the opportunity to review the log in order to supply missing or misspelled names and to verify the accuracy of the content but made no changes.</mods:note><mods:note type="personpresent" displayLabel="Persons Present">Kiyosaki and Cline.</mods:note><mods:note type="place" displayLabel="Place Conducted">Kiyosaki\'s home in Gardena, California.</mods:note><mods:note type="supportingdocuments" displayLabel="Supporting Documents">Records relating to the interview are located in the office of the UCLA Library\'s Center for Oral History Research.</mods:note><mods:note type="biographical" displayLabel="Biographical Information">Ordained as a Tibetan Buddhist nun by His Holiness the Dalai Lama in 1985. Visiting teacher at Thubten Dhargye Ling in Long Beach, California.</mods:note><mods:physicalDescription><mods:extent>6.5 hrs.</mods:extent></mods:physicalDescription><mods:identifier>21198/zz002kdzd7</mods:identifier><mods:language><mods:languageTerm>eng</mods:languageTerm></mods:language><mods:name><mods:namePart>Cline, Alex</mods:namePart><mods:role><mods:roleTerm type="text">interviewer</mods:roleTerm></mods:role></mods:name><mods:name><mods:namePart>Kiyosaki, Tenzin</mods:namePart><mods:role><mods:roleTerm type="text">interviewee</mods:roleTerm></mods:role></mods:name><mods:accessCondition>Regents of the University of California, UCLA Library.</mods:accessCondition><mods:subject authority="cohr"><mods:topic>Asian American History</mods:topic></mods:subject><mods:subject authority="cohr"><mods:topic>Buddhism</mods:topic></mods:subject></mods:mods>'
```

Relevant tags to look for:

```
<mods:subject authority="cohr">
    <mods:topic>Asian American History</mods:topic>
</mods:subject>
<mods:subject authority="cohr">
    <mods:topic>Buddhism</mods:topic>
</mods:subject>
```