### PR TITLE
SYS-1210: Easier editing of file-level item sequence numbers

### DIFF
--- a/oh_staff_ui/forms.py
+++ b/oh_staff_ui/forms.py
@@ -300,3 +300,22 @@ class FileUploadForm(forms.Form):
 
         super().__init__(*args, **kwargs)
         self.base_fields["file_name"].choices = choices
+
+
+class BaseItemSequenceFormset(forms.BaseFormSet):
+    def get_form_kwargs(self, index):
+        # override get_form_kwargs to add item_list
+        kwargs = super(BaseItemSequenceFormset, self).get_form_kwargs(index)
+        item = kwargs["items_list"][index]
+        return {"item": item}
+
+
+class ItemSequenceForm(forms.Form):
+    def __init__(self, *args, item, **kwargs):
+        # override init to allow use of item kwarg
+        self.item = item
+        super().__init__(*args, **kwargs)
+
+    sequence = forms.CharField(
+        required=True, max_length=3, widget=forms.TextInput(attrs={"size": 3})
+    )

--- a/oh_staff_ui/forms.py
+++ b/oh_staff_ui/forms.py
@@ -303,16 +303,21 @@ class FileUploadForm(forms.Form):
 
 
 class BaseItemSequenceFormset(forms.BaseFormSet):
+    # Override get_form_kwargs, used by Django to get form-level kwargs from formset
+    # and pass to each form's __init__.
     def get_form_kwargs(self, index):
-        # override get_form_kwargs to add item_list
-        kwargs = super(BaseItemSequenceFormset, self).get_form_kwargs(index)
+        kwargs = super().get_form_kwargs(index)
+        # Get each form's item from formset's items_list kwarg
         item = kwargs["items_list"][index]
+        # Return dict containing single item for each form
         return {"item": item}
 
 
 class ItemSequenceForm(forms.Form):
     def __init__(self, *args, item, **kwargs):
-        # override init to allow use of item kwarg
+        # Override init to allow use of item argument.
+        # Item is a dict defined in BaseItemSequenceFormset's get_form_kwargs.
+        # Need to keep track of item here since it's not included in form fields.
         self.item = item
         super().__init__(*args, **kwargs)
 

--- a/oh_staff_ui/templates/oh_staff_ui/edit_item.html
+++ b/oh_staff_ui/templates/oh_staff_ui/edit_item.html
@@ -44,6 +44,9 @@
             <a href="{% url 'add_item_from_parent' item.id %}">Add a child item</a>   |   
             {% endif %}
             <a href="{% url 'upload_file' item.id %}">View files</a>
+            {% if item.type.type == "Interview" %}
+               |   <a href="{% url 'order_files' item.id %}">Configure file order</a>
+            {% endif %}
         </td>
     </tr>
 </table>

--- a/oh_staff_ui/templates/oh_staff_ui/order_files.html
+++ b/oh_staff_ui/templates/oh_staff_ui/order_files.html
@@ -1,0 +1,68 @@
+{% extends 'oh_staff_ui/base.html' %}
+{% load django_bootstrap5 %}
+
+{% block content %}
+
+{% if messages %}
+<div class="box">
+{% for message in messages %}
+  <div>{{ message }}</div>
+{% endfor %}
+</div>
+{% endif %}
+
+<table class="header-metadata caption-top">
+    <caption>Item Information</caption>
+    <tr>
+        <td>Title</td>
+        <td>{{ item.title }}</td>
+    </tr>
+    <tr>
+        <td>ARK</td>
+        <td>{{ item.ark }}</td>
+    </tr>
+    <tr>
+        <td>Parent</td>
+        <td>{% if item.parent %}
+            <a href="{% url 'edit_item' item.parent.id %}">{{ item.parent }}</a>
+            {% else %}
+            {{ item.parent }}
+            {% endif %}</td>
+    </tr>
+    <tr>
+        <td>Created</td>
+        <td>{{ item.create_date }} by {{ item.created_by }}</td>
+    </tr>
+    <tr>
+        <td>Updated</td>
+        <td>{{ item.last_modified_date }} by {{ item.last_modified_by }}</td>
+    </tr>
+    <tr>
+        <td>Item Actions</td>
+        <td>
+            <a href="{% url 'edit_item' item.id %}">View metadata</a>
+        </td>
+    </tr>
+</table>
+<br>
+
+<form name="order_files" id="order_files" method="POST">
+    {% csrf_token %}
+    {{ formset.management_form }}
+    <table>
+        <tr>
+            <th>Item Name</th>
+            <th>Sequence Number</th>
+        </tr>
+        {% for form in formset %}
+        <tr>
+            <td><a href="{% url 'edit_item' form.item.id %}">{{ form.item }}</a></td>
+            <td>{% bootstrap_field form.sequence show_label=False %}</td>
+        </tr>        
+        {% endfor %}
+    </table>
+    {% bootstrap_button button_type="submit" content="Save" %}
+</form>
+
+
+{% endblock %}

--- a/oh_staff_ui/urls.py
+++ b/oh_staff_ui/urls.py
@@ -15,4 +15,5 @@ urlpatterns = [
     path("logs/", views.show_log, name="show_log"),
     path("logs/<int:line_count>", views.show_log, name="show_log"),
     path("upload_file/<int:item_id>", views.upload_file, name="upload_file"),
+    path("order_files/<int:item_id>", views.order_files, name="order_files"),
 ]

--- a/oh_staff_ui/views.py
+++ b/oh_staff_ui/views.py
@@ -180,10 +180,8 @@ def order_files(request: HttpRequest, item_id: int) -> HttpResponse:
     )
     if request.method == "POST":
         save_sequence_data(request, children)
-        # get children again, in case they were reordered
-        children = list(
-            ProjectItem.objects.filter(parent=item).order_by("sequence", "title")
-        )
+        # Redirect (via GET) so user refreshing page does not resubmit form.
+        return redirect("order_files", item_id=item_id)
     formset = get_sequence_formset(children)
     context = {"item": item, "formset": formset}
     return render(request, "oh_staff_ui/order_files.html", context)

--- a/oh_staff_ui/views_utils.py
+++ b/oh_staff_ui/views_utils.py
@@ -374,10 +374,12 @@ def get_parent_item(item_id: int) -> ProjectItem:
 def get_sequence_formset(items: list) -> BaseFormSet:
     sequence_list = []
     for item in items:
-        sequence_list.append({"item": item, "sequence": item.sequence})
+        sequence_list.append({"sequence": item.sequence})
     factory = formset_factory(
         ItemSequenceForm, extra=0, formset=BaseItemSequenceFormset, validate_min=True
     )
+    # ItemSequenceForm only includes sequence field, so we need to pass items_list to formset
+    # via form_kwargs in order to associate each sequence with its item.
     formset = factory(initial=sequence_list, form_kwargs={"items_list": items})
     return formset
 
@@ -386,6 +388,7 @@ def save_sequence_data(request: HttpRequest, items_list: list) -> None:
     factory = formset_factory(
         ItemSequenceForm, extra=0, formset=BaseItemSequenceFormset, validate_min=True
     )
+    # Include items_list in form_kwargs so we can associate each sequence with its item
     formset = factory(request.POST, form_kwargs={"items_list": items_list})
     if formset.is_valid():
         for form in formset:

--- a/oh_staff_ui/views_utils.py
+++ b/oh_staff_ui/views_utils.py
@@ -10,12 +10,14 @@ from django.utils import timezone
 from oh_staff_ui.forms import (
     AltIdForm,
     AltTitleForm,
+    BaseItemSequenceFormset,
     DateForm,
     DescriptionForm,
     FormatForm,
     ProjectItemForm,
     CopyrightUsageForm,
     LanguageUsageForm,
+    ItemSequenceForm,
     NameUsageForm,
     PublisherUsageForm,
     ResourceUsageForm,
@@ -367,3 +369,34 @@ def get_relatives(item: ProjectItem) -> dict:
 
 def get_parent_item(item_id: int) -> ProjectItem:
     return ProjectItem.objects.get(pk=item_id).parent
+
+
+def get_sequence_formset(items: list) -> BaseFormSet:
+    sequence_list = []
+    for item in items:
+        sequence_list.append({"item": item, "sequence": item.sequence})
+    factory = formset_factory(
+        ItemSequenceForm, extra=0, formset=BaseItemSequenceFormset, validate_min=True
+    )
+    formset = factory(initial=sequence_list, form_kwargs={"items_list": items})
+    return formset
+
+
+def save_sequence_data(request: HttpRequest, items_list: list) -> None:
+    factory = formset_factory(
+        ItemSequenceForm, extra=0, formset=BaseItemSequenceFormset, validate_min=True
+    )
+    formset = factory(request.POST, form_kwargs={"items_list": items_list})
+    if formset.is_valid():
+        for form in formset:
+            if form.is_valid():
+                sequence = form.cleaned_data["sequence"]
+                child_item = form.item
+                child_item.sequence = sequence
+                child_item.last_modified_date = timezone.now()
+                child_item.last_modified_by = request.user
+                child_item.save()
+        messages.success(request, "Sequence numbers have been saved.")
+    else:
+        messages.error(request, "Problem saving data!")
+        logger.error(f"{formset.errors=}")


### PR DESCRIPTION
Implements [SYS-1210](https://jira.library.ucla.edu/browse/SYS-1210)

On interview-level items only, adds a link ("Configure file order") to a new template (`order_files`) containing a form allowing users to edit sequence numbers on child ProjectItems.

This form does not enforce any new validation on sequence numbers, i.e. users can still enter duplicate sequence numbers, numbers < 1, etc. Changing a sequence number via this form will also update the modified date and modified by fields on the associated item. 

Screenshots:
<img width="507" alt="image" src="https://github.com/UCLALibrary/oral-history-staff-ui/assets/7283991/65b92b72-5447-41f0-b8ee-1598022bf5da">
---
<img width="507" alt="image" src="https://github.com/UCLALibrary/oral-history-staff-ui/assets/7283991/c1a4b13d-093a-4b0d-ac9b-d12d615e429d">
