### PR TITLE
SYS-1290: Add parent title to search results

### DIFF
--- a/oh_staff_ui/templates/oh_staff_ui/search_results.html
+++ b/oh_staff_ui/templates/oh_staff_ui/search_results.html
@@ -14,7 +14,7 @@
     <tr>
         <td><a href="{% url 'edit_item' item.id %}">{{ item.ark }}</a></td>
         <td>{{ item.title }}</td>
-        <!-- Keyword searches will have item.parent. All others have item.parent__title. If None, display blank. --> 
+        {# Keyword searches will have item.parent. All others have item.parent__title. If None, display blank. #}
         <td>{% if item.parent__title %}{{ item.parent__title }}
             {% elif item.parent %}{{ item.parent }}{% endif %}</td>
     </tr>

--- a/oh_staff_ui/templates/oh_staff_ui/search_results.html
+++ b/oh_staff_ui/templates/oh_staff_ui/search_results.html
@@ -2,15 +2,21 @@
 
 {% block content %}
 {% if results %}
-<table class="search-results">
-    <tr>
-        <th>ARK</th>
-        <th>Title</th>
-    </tr>
+<table class="table">
+    <thead>
+        <tr>
+            <th>ARK</th>
+            <th>Title</th>
+            <th>Parent</th>
+        </tr>
+    </thead>
     {% for item in results %}
     <tr>
         <td><a href="{% url 'edit_item' item.id %}">{{ item.ark }}</a></td>
-        <td>{{ item.title}}</td>
+        <td>{{ item.title }}</td>
+        <!-- Keyword searches will have item.parent. All others have item.parent__title. If None, display blank. --> 
+        <td>{% if item.parent__title %}{{ item.parent__title }}
+            {% elif item.parent %}{{ item.parent }}{% endif %}</td>
     </tr>
     {% endfor %}
 </table>

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -24,14 +24,6 @@ td.search-type{
     min-width: 15rem
 }
 
-.search-results {
-   width: 100%;
-}
-
-.search-results td {
-    border: 1px solid;
-}
-
 .current-item {
     font-weight: bold;
 }


### PR DESCRIPTION
Implements [SYS-1290](https://jira.library.ucla.edu/browse/SYS-1290)

Small view, template, and CSS changes to support display of item Parent in search results. Some notes:

* Parents are not currently linked, in keeping with how Title is displayed.
* If an item has no parent, the Parent column is empty.
* Using Bootstrap table styling was easier than dealing with potentially very long lines with text wrapping, so I've applied that to the search results table and removed two now-unused CSS rules.