### PR TITLE
SYS-1291: Provide ability to browse collection

### DIFF
--- a/oh_staff_ui/templates/oh_staff_ui/base.html
+++ b/oh_staff_ui/templates/oh_staff_ui/base.html
@@ -19,6 +19,7 @@
     <ul class="navbar">
         <li><a href="/item_search/">Item Search</a></li>
         <li><a href="/add_item/">Add Series</a></li>
+        <li><a href="/browse/">Browse Series</a></li>
         <li><a href="/admin/">Admin (Metadata Configuration)</a></li>
         <li><a href="/logs/">Logs</a></li>
         <li><a href="/admin/logout/">Logout</a></li>

--- a/oh_staff_ui/templates/oh_staff_ui/browse.html
+++ b/oh_staff_ui/templates/oh_staff_ui/browse.html
@@ -1,0 +1,23 @@
+{% extends 'oh_staff_ui/base.html' %}
+{% load django_bootstrap5 %}
+
+{% block content %}
+
+{% if messages %}
+<div class="box">
+{% for message in messages %}
+  <div>{{ message }}</div>
+{% endfor %}
+</div>
+{% endif %}
+
+<div>
+    <p>This list contains all Series and Interviews in the database. 
+        Click the arrows to view Interviews under each Series. 
+        Any Series with no arrow has no Interviews.</p>
+    <ul class="tree">
+        {% include "oh_staff_ui/item_tree.html" %}
+    </ul>
+</div>
+
+{% endblock %}

--- a/oh_staff_ui/urls.py
+++ b/oh_staff_ui/urls.py
@@ -16,4 +16,5 @@ urlpatterns = [
     path("logs/<int:line_count>", views.show_log, name="show_log"),
     path("upload_file/<int:item_id>", views.upload_file, name="upload_file"),
     path("order_files/<int:item_id>", views.order_files, name="order_files"),
+    path("browse/", views.browse, name="browse"),
 ]

--- a/oh_staff_ui/views.py
+++ b/oh_staff_ui/views.py
@@ -17,6 +17,7 @@ from oh_staff_ui.views_utils import (
     construct_keyword_query,
     get_ark,
     get_edit_item_context,
+    get_series_and_interviews,
     get_keyword_results,
     get_result_items,
     get_sequence_formset,
@@ -201,3 +202,9 @@ def order_files(request: HttpRequest, item_id: int) -> HttpResponse:
     formset = get_sequence_formset(children)
     context = {"item": item, "formset": formset}
     return render(request, "oh_staff_ui/order_files.html", context)
+
+
+@login_required
+def browse(request: HttpRequest) -> HttpResponse:
+    context = {"relatives": get_series_and_interviews()}
+    return render(request, "oh_staff_ui/browse.html", context)

--- a/oh_staff_ui/views.py
+++ b/oh_staff_ui/views.py
@@ -17,7 +17,7 @@ from oh_staff_ui.views_utils import (
     construct_keyword_query,
     get_ark,
     get_edit_item_context,
-    get_series_and_interviews,
+    get_all_series_and_interviews,
     get_keyword_results,
     get_result_items,
     get_sequence_formset,
@@ -206,5 +206,5 @@ def order_files(request: HttpRequest, item_id: int) -> HttpResponse:
 
 @login_required
 def browse(request: HttpRequest) -> HttpResponse:
-    context = {"relatives": get_series_and_interviews()}
+    context = {"relatives": get_all_series_and_interviews()}
     return render(request, "oh_staff_ui/browse.html", context)

--- a/oh_staff_ui/views_utils.py
+++ b/oh_staff_ui/views_utils.py
@@ -369,7 +369,7 @@ def get_relatives(item: ProjectItem) -> dict:
     return relatives
 
 
-def get_series_and_interviews() -> dict:
+def get_all_series_and_interviews() -> dict:
     # For Series browse page, get only Series and Interviews (not File items)
     # formatted as nested dicts for item_tree template.
     series_tree = {}

--- a/oh_staff_ui/views_utils.py
+++ b/oh_staff_ui/views_utils.py
@@ -369,6 +369,22 @@ def get_relatives(item: ProjectItem) -> dict:
     return relatives
 
 
+def get_series_and_interviews() -> dict:
+    # For Series browse page, get only Series and Interviews (not File items)
+    # formatted as nested dicts for item_tree template.
+    series_tree = {}
+    all_series = ProjectItem.objects.filter(type__type="Series").order_by("title")
+    for series in all_series:
+        interview_tree = {}
+        child_interviews = ProjectItem.objects.filter(parent=series).order_by(
+            "sequence", "title"
+        )
+        for interview in child_interviews:
+            interview_tree[interview] = None
+        series_tree[series] = interview_tree
+    return series_tree
+
+
 def get_parent_item(item_id: int) -> ProjectItem:
     return ProjectItem.objects.get(pk=item_id).parent
 


### PR DESCRIPTION
Implements [SYS-1291](https://jira.library.ucla.edu/browse/SYS-1291)

This PR adds a new page, accessible through a new "Browse Series" link in the navbar, with a tree containing links to all Series and Interviews (but not Files). This new page reuses the `item_tree` template and includes a bit of text at the top intended to help set user expectations - let me know if you think this should be edited/better formatted/removed.

Screenshot:
<img width="1247" alt="image" src="https://github.com/UCLALibrary/oral-history-staff-ui/assets/7283991/dc4c59e4-4b99-4353-861d-6cb201ec0486">
