### PR TITLE
SYS-1296: Change resource label on item editing form

### DIFF
--- a/charts/prod-ohstaff-values.yaml
+++ b/charts/prod-ohstaff-values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: uclalibrary/oral-history-staff-ui
-  tag: v0.9.6
+  tag: v0.9.7
   pullPolicy: Always
 
 nameOverride: ""

--- a/oh_staff_ui/templates/oh_staff_ui/edit_item.html
+++ b/oh_staff_ui/templates/oh_staff_ui/edit_item.html
@@ -161,7 +161,7 @@
         {% for resource_form in resource_formset %}
         <tr>
             <td class="label">{% if forloop.first %}
-                {% bootstrap_button id="resource_add" button_type="button" button_class="btn-primary add_formset" content="+" %}&nbsp;Resource(s):
+                {% bootstrap_button id="resource_add" button_type="button" button_class="btn-primary add_formset" content="+" %}&nbsp;Type(s) of Resource:
                 {% endif %}
             </td>
             <td class="qualifier">{% bootstrap_field resource_form.usage_id %} {% bootstrap_field resource_form.type show_label=False %}</td>

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -33,6 +33,10 @@ td.qualifier {
     vertical-align: baseline;
 }
 
+td.label {
+    white-space: nowrap;
+}
+
 td.qualifier {
     min-width: 15rem
 }


### PR DESCRIPTION
Implements [SYS-1296](https://jira.library.ucla.edu/browse/SYS-1296).
Bumps version to `v0.9.7` to deploy this and other recent UI changes.

This PR changes the label from `Resource(s)` to `Type(s) of Resource` in the `edit_item` template.  It also tweaks the CSS to prevent the longer label text from wrapping.

Testing: No automated tests.  Look at http://127.0.0.1:8000/item/251 or any other item to see the new wording and confirm the label text does not wrap.
