### PR TITLE
SYS-1292: Show item type in search results

### DIFF
--- a/charts/prod-ohstaff-values.yaml
+++ b/charts/prod-ohstaff-values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: uclalibrary/oral-history-staff-ui
-  tag: v0.9.7
+  tag: v0.9.8
   pullPolicy: Always
 
 nameOverride: ""

--- a/oh_staff_ui/forms.py
+++ b/oh_staff_ui/forms.py
@@ -124,6 +124,7 @@ class ProjectItemForm(forms.Form):
 
 
 class ItemSearchForm(forms.Form):
+    # If these change, views_utils.get_search_results() must be updated too.
     search_types = [
         ("title", "Title"),
         ("status", "Status"),

--- a/oh_staff_ui/templates/oh_staff_ui/search_results.html
+++ b/oh_staff_ui/templates/oh_staff_ui/search_results.html
@@ -6,6 +6,7 @@
     <thead>
         <tr>
             <th>ARK</th>
+            <th>Type</th>
             <th>Title</th>
             <th>Parent</th>
         </tr>
@@ -13,10 +14,10 @@
     {% for item in results %}
     <tr>
         <td><a href="{% url 'edit_item' item.id %}">{{ item.ark }}</a></td>
+        <td>{{ item.type }}</td>
         <td>{{ item.title }}</td>
-        {# Keyword searches will have item.parent. All others have item.parent__title. If None, display blank. #}
-        <td>{% if item.parent__title %}{{ item.parent__title }}
-            {% elif item.parent %}{{ item.parent }}{% endif %}</td>
+        {# If parent is None (item is a Series), display blank. #}
+        <td>{% if item.parent %}{{ item.parent }}{% endif %}</td>
     </tr>
     {% endfor %}
 </table>

--- a/oh_staff_ui/views.py
+++ b/oh_staff_ui/views.py
@@ -14,12 +14,10 @@ from oh_staff_ui.forms import (
 )
 from oh_staff_ui.models import MediaFile, MediaFileError, ProjectItem
 from oh_staff_ui.views_utils import (
-    construct_keyword_query,
     get_ark,
     get_edit_item_context,
     get_all_series_and_interviews,
-    get_keyword_results,
-    get_result_items,
+    get_search_results,
     get_sequence_formset,
     run_process_file_command,
     save_all_item_data,
@@ -110,33 +108,7 @@ def item_search(request: HttpRequest) -> HttpResponse:
 
 @login_required
 def search_results(request: HttpRequest, search_type: str, query: str) -> HttpResponse:
-    if search_type == "title":
-        full_query = construct_keyword_query("title", query)
-        # Explicitly get values needed in search results template so we can access parent__title,
-        # not just parent_id.
-        results = (
-            ProjectItem.objects.filter(full_query)
-            .order_by("title")
-            .values("id", "ark", "title", "parent__title")
-        )
-    elif search_type == "ark":
-        results = (
-            ProjectItem.objects.filter(ark__icontains=query)
-            .order_by("ark")
-            .values("id", "ark", "title", "parent__title")
-        )
-    elif search_type == "status":
-        results = (
-            ProjectItem.objects.filter(status__status=query)
-            .order_by("title")
-            .values("id", "ark", "title", "parent__title")
-        )
-    elif search_type == "keyword":
-        search_data = get_keyword_results(query)
-        # get_result_items() doesn't use queryset .values(), so we'll get item parent
-        # instead of parent_id.
-        # Difference in fields returned from keyword vs. other searches is handled in template.
-        results = get_result_items(search_data)
+    results = get_search_results(search_type, query)
     return render(request, "oh_staff_ui/search_results.html", {"results": results})
 
 

--- a/oh_staff_ui/views_utils.py
+++ b/oh_staff_ui/views_utils.py
@@ -5,7 +5,7 @@ import uuid
 from django.conf import settings
 from django.contrib import messages
 from django.core.management import call_command
-from django.db.models import Q, Model, CharField
+from django.db.models import CharField, Model, Q, QuerySet
 from django.forms import BaseFormSet, Form, formset_factory
 from django.http.request import HttpRequest  # for code completion
 from django.utils import timezone
@@ -76,7 +76,7 @@ def get_keyword_results(query: str) -> list:
     return search_results
 
 
-def get_result_items(queryset_list: list) -> list:
+def get_result_items(queryset_list: list) -> list[ProjectItem]:
     # convert list of querysets to list of ProjectItems for display
     output_projectitems = []
     # by order of search_models in get_keyword_results(),
@@ -108,6 +108,30 @@ def get_result_items(queryset_list: list) -> list:
     # sort output list by title
     output_projectitems_deduped.sort(key=lambda x: x.title.lower())
     return output_projectitems_deduped
+
+
+def get_search_results(search_type: str, query: str) -> list[ProjectItem]:
+    # Return a list of items matching the search.  Different searches have
+    # different return types and sort orders; this unifies them for consistent
+    # use in the view and template.
+    if search_type == "title":
+        full_query = construct_keyword_query("title", query)
+        qs_results = ProjectItem.objects.filter(full_query).order_by("title")
+    elif search_type == "ark":
+        qs_results = ProjectItem.objects.filter(ark__icontains=query).order_by("ark")
+    elif search_type == "status":
+        qs_results = ProjectItem.objects.filter(status__status=query).order_by("title")
+    elif search_type == "keyword":
+        search_data = get_keyword_results(query)
+        # This is a sorted list of ProjectItems already, so does not need conversion to list below.
+        qs_results = get_result_items(search_data)
+    # Convert query results from QuerySet to list of items, if needed.
+    # qs_results is already sorted as desired based on search_type.
+    if isinstance(qs_results, QuerySet):
+        results = [item for item in qs_results]
+    else:
+        results = qs_results
+    return results
 
 
 def get_ark() -> str:


### PR DESCRIPTION
Implements [SYS-1292](https://jira.library.ucla.edu/browse/SYS-1292).  Bumps version to `v0.9.8` for deployment.

This PR adds item type (currently Series, Interview, Audio) to the search results, to make the context of each result clearer.

The original code handled keyword search results differently from other search types, with the `search_results` view and template both needing to account for this difference.  As part of this PR, the logic moves from the view & template to a new utility function, `views_utils.get_search_results()`  This returns consistent data, an appropriately-sorted list of items, so the view can just pass that data to the template for uniform display.

Testing:
No new (or old) automated tests; all tests still pass.
Do searches of different types to confirm `Type` now displays between `ARK` and `Title`.
http://127.0.0.1:8000/item_search/

Screenshot example:
![oh_search_results_with_type](https://github.com/UCLALibrary/oral-history-staff-ui/assets/2213836/f6253912-1643-4c99-91ca-e410b219a5c9)
