### PR TITLE
Sys 1211/management cmd mods export

### DIFF
--- a/oh_staff_ui/classes/OralHistoryMods.py
+++ b/oh_staff_ui/classes/OralHistoryMods.py
@@ -234,7 +234,7 @@ class OralHistoryMods(MODSv34):
     def write_mods_record(self):
         ark_ns = self._item.ark.replace("/", "-")
 
-        p = Path(f"{settings.OH_STATIC}/mods")
+        p = Path(f"{settings.MEDIA_ROOT}/{settings.OH_STATIC}/mods")
         p.mkdir(exist_ok=True, parents=True)
 
         with open(f"{p}/{ark_ns}-mods.xml", "wb") as mods_file:

--- a/oh_staff_ui/classes/OralHistoryMods.py
+++ b/oh_staff_ui/classes/OralHistoryMods.py
@@ -1,4 +1,6 @@
 import logging
+from django.conf import settings
+from pathlib import Path
 from eulxml import xmlmap
 from eulxml.xmlmap import mods
 from eulxml.xmlmap.mods import MODSv34
@@ -25,6 +27,7 @@ class OralHistoryMods(MODSv34):
     def __init__(self, project_item):
         super().__init__()
         self._item = project_item
+        self.populate_fields()
 
     def populate_fields(self):
         self._populate_alttitle()
@@ -227,6 +230,15 @@ class OralHistoryMods(MODSv34):
                 ri.abstract.text = d.value
 
             self.related_items.append(ri)
+
+    def write_mods_record(self):
+        ark_ns = self._item.ark.replace("/", "-")
+
+        p = Path(f"{settings.OH_STATIC}/mods")
+        p.mkdir(exist_ok=True, parents=True)
+
+        with open(f"{p}/{ark_ns}-mods.xml", "wb") as mods_file:
+            mods_file.write(self.serializeDocument(pretty=True))
 
 
 # Extended classes to supply some additional attributes not in stock library that we use

--- a/oh_staff_ui/classes/OralHistoryMods.py
+++ b/oh_staff_ui/classes/OralHistoryMods.py
@@ -239,7 +239,9 @@ class OralHistoryMods(MODSv34):
 
         with open(f"{p}/{ark_ns}-mods.xml", "wb") as mods_file:
             mods_file.write(self.serializeDocument(pretty=True))
-            logger.info(f"Wrote MODS for item id: {self._item.id} to file: {ark_ns}-mods.xml")
+            logger.info(
+                f"Wrote MODS for item id: {self._item.id} to file: {ark_ns}-mods.xml"
+            )
 
 
 # Extended classes to supply some additional attributes not in stock library that we use

--- a/oh_staff_ui/classes/OralHistoryMods.py
+++ b/oh_staff_ui/classes/OralHistoryMods.py
@@ -239,6 +239,7 @@ class OralHistoryMods(MODSv34):
 
         with open(f"{p}/{ark_ns}-mods.xml", "wb") as mods_file:
             mods_file.write(self.serializeDocument(pretty=True))
+            logger.info(f"Wrote MODS for item id: {self._item.id} to file: {ark_ns}-mods.xml")
 
 
 # Extended classes to supply some additional attributes not in stock library that we use

--- a/oh_staff_ui/management/commands/create_mods_records.py
+++ b/oh_staff_ui/management/commands/create_mods_records.py
@@ -1,20 +1,20 @@
 import logging
 from django.core.management.base import BaseCommand
+from django.core.management.base import CommandError
 from oh_staff_ui.classes.OralHistoryMods import OralHistoryMods
 from oh_staff_ui.models import ProjectItem
-
-# For handling command-line processing
-from django.contrib.auth.models import User
-
 
 logger = logging.getLogger(__name__)
 
 
 def create_mods_records(item_id: int) -> None:
     """Given an item_id write the related MODS record to public location"""
-    pi = ProjectItem.objects.filter(id=item_id).first()
-    if pi:
+    try:
+        pi = ProjectItem.objects.get(id=item_id)
         OralHistoryMods(pi).write_mods_record()
+    except (ProjectItem.DoesNotExist) as e:
+        logger.error(e)
+        raise CommandError(f"ProjectItem with id {item_id} does not exist")
 
 
 class Command(BaseCommand):

--- a/oh_staff_ui/management/commands/create_mods_records.py
+++ b/oh_staff_ui/management/commands/create_mods_records.py
@@ -28,8 +28,8 @@ class Command(BaseCommand):
             required=True,
             help="The id of the item to export mods record of",
         )
-    
+
     def handle(self, *args, **options):
-        
+
         item_id = options["item_id"]
         create_mods_records(item_id)

--- a/oh_staff_ui/management/commands/create_mods_records.py
+++ b/oh_staff_ui/management/commands/create_mods_records.py
@@ -1,0 +1,28 @@
+import logging
+from django.core.management.base import BaseCommand
+from oh_staff_ui.classes.OralHistoryMods import OralHistoryMods
+from oh_staff_ui.models import ProjectItem
+
+# For handling command-line processing
+from django.contrib.auth.models import User
+
+
+logger = logging.getLogger(__name__)
+
+
+def export_mods_record(item_id: int) -> None:
+    """Given an item_id write the related MODS record to public location"""
+    logger.info(f"{item_id = }")
+
+
+class Command(BaseCommand):
+    help = "Django management command to process Oral History files"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "-i",
+            "--item_id",
+            type=int,
+            required=True,
+            help="The id of the item to export mods record of",
+        )

--- a/oh_staff_ui/management/commands/create_mods_records.py
+++ b/oh_staff_ui/management/commands/create_mods_records.py
@@ -10,13 +10,15 @@ from django.contrib.auth.models import User
 logger = logging.getLogger(__name__)
 
 
-def export_mods_record(item_id: int) -> None:
+def create_mods_records(item_id: int) -> None:
     """Given an item_id write the related MODS record to public location"""
-    logger.info(f"{item_id = }")
+    pi = ProjectItem.objects.filter(id=item_id).first()
+    if pi:
+        OralHistoryMods(pi).write_mods_record()
 
 
 class Command(BaseCommand):
-    help = "Django management command to process Oral History files"
+    help = "Django management command to generate Oral History MODS records"
 
     def add_arguments(self, parser):
         parser.add_argument(
@@ -26,3 +28,8 @@ class Command(BaseCommand):
             required=True,
             help="The id of the item to export mods record of",
         )
+    
+    def handle(self, *args, **options):
+        
+        item_id = options["item_id"]
+        create_mods_records(item_id)

--- a/oh_staff_ui/tests.py
+++ b/oh_staff_ui/tests.py
@@ -1317,6 +1317,15 @@ class ModsTestCase(TestCase):
             b'<mods:relatedItem type="series">' not in ohmods.serializeDocument()
         )
 
+    def test_writing_single_mods(self):
+        ohmods = self.get_mods_from_interview_item()
+        ohmods.write_mods_record()
+
+        ark_ns = self.interview_item.ark.replace("/", "-")
+        # Verify file exists
+        p = Path(f"{settings.MEDIA_ROOT}/{settings.OH_STATIC}/mods/{ark_ns}-mods.xml")
+        self.assertTrue(p.is_file())
+
 
 class FileMetadataMigrationTestCase(SimpleTestCase):
     # Test logic not already covered by OralHistoryFile tests.


### PR DESCRIPTION
This adds a management command and test and write a single record to a public mods directory specified by `ProjectItem.id`. A future PR on this same ticket will add management options and test for bulk export, calling similar functions.

The exported file name is the item ark with `/` swapped for `-` and `-mods.xml` appended. 
A full filename would look like:
`21198-zz00123456-mods.xml`

This is written to the static root directory under a `mods` subdirectory.
`{MEDIA_ROOT}/{OH_STATIC}/mods/{filename}.xml`

If a file exists, it is overwritten without warning.

To confirm proper behavior:
- Run tests, all should pass. Additional test writes a sample object mods record and checks for existence, calling the write function directly, as opposed to the management command
- Run the `create_mods_records` management command, choose any item id and run the following from the cli, 2504 is used below
`docker-compose exec django python manage.py create_mods_records -i 2504`

A file will be created in the container under `/tmp/media_dev/oh_static/mods` with the pattern described above (`21198-zz002knx8t-mods.xml` in the example command above/



