### PR TITLE
Reworked mods export management command, added bulk options

### DIFF
--- a/oh_staff_ui/management/commands/create_mods_records.py
+++ b/oh_staff_ui/management/commands/create_mods_records.py
@@ -17,7 +17,7 @@ class Command(BaseCommand):
             nargs="+",
             type=int,
             required=False,
-            help="The id of the item to export mods record of, multiple ids are permitted",
+            help="The id(s) of the item to export mods record of",
         )
         parser.add_argument(
             "-b",
@@ -43,6 +43,7 @@ class Command(BaseCommand):
             pi = ProjectItem.objects.get(id=item_id)
             OralHistoryMods(pi).write_mods_record()
             logger.info(f"Item: {pi.id} with ark {pi.ark} MODS record written")
+
         except (ProjectItem.DoesNotExist) as e:
             logger.error(e)
             raise CommandError(f"ProjectItem with id {item_id} does not exist")

--- a/oh_staff_ui/management/commands/create_mods_records.py
+++ b/oh_staff_ui/management/commands/create_mods_records.py
@@ -7,16 +7,6 @@ from oh_staff_ui.models import ProjectItem
 logger = logging.getLogger(__name__)
 
 
-def create_mods_records(item_id: int) -> None:
-    """Given an item_id write the related MODS record to public location"""
-    try:
-        pi = ProjectItem.objects.get(id=item_id)
-        OralHistoryMods(pi).write_mods_record()
-    except (ProjectItem.DoesNotExist) as e:
-        logger.error(e)
-        raise CommandError(f"ProjectItem with id {item_id} does not exist")
-
-
 class Command(BaseCommand):
     help = "Django management command to generate Oral History MODS records"
 
@@ -24,12 +14,55 @@ class Command(BaseCommand):
         parser.add_argument(
             "-i",
             "--item_id",
+            nargs="+",
             type=int,
-            required=True,
-            help="The id of the item to export mods record of",
+            required=False,
+            help="The id of the item to export mods record of, multiple ids are permitted",
+        )
+        parser.add_argument(
+            "-b",
+            "--bulk",
+            type=str,
+            required=False,
+            choices=["series", "interview", "audio", "all"],
+            help="The type of items to bulk export, choices are: series, interview, assets and all",
         )
 
     def handle(self, *args, **options):
 
-        item_id = options["item_id"]
-        create_mods_records(item_id)
+        if options["item_id"]:
+            for item_id in options["item_id"]:
+                self._create_mods_record(item_id)
+
+        if options["bulk"]:
+            self._create_bulk_mods_records(options["bulk"])
+
+    def _create_mods_record(self, item_id: int) -> None:
+        """Given an item_id write the related MODS record to public location"""
+        try:
+            pi = ProjectItem.objects.get(id=item_id)
+            OralHistoryMods(pi).write_mods_record()
+            logger.info(f"Item: {pi.id} with ark {pi.ark} MODS record written")
+        except (ProjectItem.DoesNotExist) as e:
+            logger.error(e)
+            raise CommandError(f"ProjectItem with id {item_id} does not exist")
+
+    def _create_bulk_mods_records(self, category: str) -> None:
+        """Only items of status 'Completed' are allowed for bulk operations"""
+        err_items = ()
+        pi_set = ProjectItem.objects.filter(status__status__iexact="completed")
+        if category != "all":
+            pi_set = pi_set.filter(type__type__iexact=category)
+
+        for pi in pi_set:
+            try:
+                self._create_mods_record(pi.id)
+            except (CommandError) as e:
+                logger.error(e)
+                err_items.append(pi)
+
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"{pi_set.count() - len(err_items)} of {pi_set.count()} MODS records written"
+            )
+        )

--- a/oh_staff_ui/management/commands/create_mods_records.py
+++ b/oh_staff_ui/management/commands/create_mods_records.py
@@ -8,16 +8,15 @@ logger = logging.getLogger(__name__)
 
 
 class Command(BaseCommand):
-    help = "Django management command to generate Oral History MODS records"
+    help = "Django management command to generate Oral History MODS records, and must be run with 1 argument"
 
     def add_arguments(self, parser):
         parser.add_argument(
             "-i",
             "--item_id",
-            nargs="+",
             type=int,
             required=False,
-            help="The id(s) of the item to export mods record of",
+            help="The id of the item to export mods record of",
         )
         parser.add_argument(
             "-b",
@@ -25,24 +24,28 @@ class Command(BaseCommand):
             type=str,
             required=False,
             choices=["series", "interview", "audio", "all"],
-            help="The type of items to bulk export, choices are: series, interview, assets and all",
+            help="The type of items to bulk export MODS records, choices are: series, interview, assets and all",
         )
 
     def handle(self, *args, **options):
 
-        if options["item_id"]:
-            for item_id in options["item_id"]:
-                self._create_mods_record(item_id)
+        if bool(options["item_id"]) ^ bool(options["bulk"]):
+            
+            if options["item_id"]:
+                self._create_mods_record(options["item_id"])
 
-        if options["bulk"]:
-            self._create_bulk_mods_records(options["bulk"])
+            if options["bulk"]:
+                self._create_bulk_mods_records(options["bulk"])
+        
+        else:
+            raise CommandError("This command must be executed with 1 argument")
 
     def _create_mods_record(self, item_id: int) -> None:
         """Given an item_id write the related MODS record to public location"""
         try:
             pi = ProjectItem.objects.get(id=item_id)
             OralHistoryMods(pi).write_mods_record()
-            logger.info(f"Item: {pi.id} with ark {pi.ark} MODS record written")
+            logger.debug(f"Item: {pi.id} with ark {pi.ark} MODS record written")
 
         except (ProjectItem.DoesNotExist) as e:
             logger.error(e)

--- a/oh_staff_ui/management/commands/create_mods_records.py
+++ b/oh_staff_ui/management/commands/create_mods_records.py
@@ -30,13 +30,13 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
 
         if bool(options["item_id"]) ^ bool(options["bulk"]):
-            
+
             if options["item_id"]:
                 self._create_mods_record(options["item_id"])
 
             if options["bulk"]:
                 self._create_bulk_mods_records(options["bulk"])
-        
+
         else:
             raise CommandError("This command must be executed with 1 argument")
 


### PR DESCRIPTION
This adds PR bulk export MODS option via django management command.

A user may export single items with no restrictions via the `--item` option, or may use `--bulk` with a select number of item types to export MODS record in bulk. 

The bulk options include:
- series
- interview
- audio
- all

If there is a problem writing a record in a bulk setting, the `CommandError` is captured, the `ProjectItem.id` collected, and the remainder of the `ProjectItem` list is exported. The user is shown a result message at the end of operation.

Usage and testing:

The MODS writing logic has not changed, so an additional test has not been added.

To test the management command, run the following:
`docker-compose exec django python manage.py create_mods_records -b series`

Assuming a full test database, the output should be similar to:
`99 of 99 MODS records written`

For a larger set, run:
`docker-compose exec django python manage.py create_mods_records -b all`
`4700 of 4700 MODS records written`

This should only take about 2 minutes.

The content can be verified by looking at the `/tmp/media_dev/oh_static/mods` directory on the django container.