### PR TITLE
Sys 1308/oai envelope

### DIFF
--- a/oh_staff_ui/classes/OralHistoryMods.py
+++ b/oh_staff_ui/classes/OralHistoryMods.py
@@ -1,7 +1,6 @@
 import logging
 from django.conf import settings
 from pathlib import Path
-from lxml import etree
 from eulxml import xmlmap
 from eulxml.xmlmap import mods
 from eulxml.xmlmap.mods import MODSv34

--- a/oh_staff_ui/classes/OralHistoryMods.py
+++ b/oh_staff_ui/classes/OralHistoryMods.py
@@ -1,6 +1,5 @@
 import logging
 from django.conf import settings
-from datetime import datetime
 from pathlib import Path
 from lxml import etree
 from eulxml import xmlmap
@@ -234,7 +233,7 @@ class OralHistoryMods(MODSv34):
             self.related_items.append(ri)
 
     def write_mods_record(self):
-        ark_ns = self._item.ark.replace("/", "-")
+        ark_ns = self.get_ark_no_slash(self._item.ark)
 
         p = Path(f"{settings.MEDIA_ROOT}/{settings.OH_STATIC}/mods")
         p.mkdir(exist_ok=True, parents=True)
@@ -244,31 +243,29 @@ class OralHistoryMods(MODSv34):
             logger.info(
                 f"Wrote MODS for item id: {self._item.id} to file: {ark_ns}-mods.xml"
             )
-    
-    def add_oai_envelope(self):
 
-        ark_ns = self._item.ark.replace("/", "-")
+    def add_oai_envelope(self) -> etree.Element:
 
-        rec = etree.Element("record")
-        h = etree.Element("header")
+        record_el = etree.Element("record")
+        header_el = etree.Element("header")
 
-        i = etree.Element("identifier")
-        i.text = ark_ns
-        
-        ds = etree.Element("datestamp")
-        ds.text = self._item.create_date.strftime('%Y-%m-%d')
-        
-        h.append(i)
-        h.append(ds)
-        rec.append(h)
+        id_el = etree.Element("identifier")
+        id_el.text = self._item.ark
 
-        md = etree.Element("metadata")
-        md.append(self.node)
-        rec.append(md)
+        date_el = etree.Element("datestamp")
+        date_el.text = self._item.create_date.strftime("%Y-%m-%d")
 
-        return rec
+        header_el.append(id_el)
+        header_el.append(date_el)
+        record_el.append(header_el)
 
-# Extended classes to supply some additional attributes not in stock library that we use
+        metadata_el = etree.Element("metadata")
+        metadata_el.append(self.node)
+        record_el.append(metadata_el)
+
+        return record_el
+
+    # Extended classes to supply some additional attributes not in stock library that we use
 
 
 class LocationOH(mods.Location):

--- a/oh_staff_ui/classes/OralHistoryMods.py
+++ b/oh_staff_ui/classes/OralHistoryMods.py
@@ -233,15 +233,13 @@ class OralHistoryMods(MODSv34):
             self.related_items.append(ri)
 
     def write_mods_record(self):
-        ark_ns = self.get_ark_no_slash(self._item.ark)
-
         p = Path(f"{settings.MEDIA_ROOT}/{settings.OH_STATIC}/mods")
         p.mkdir(exist_ok=True, parents=True)
 
-        with open(f"{p}/{ark_ns}-mods.xml", "wb") as mods_file:
+        with open(f"{p}/{self._item.ark_ns}-mods.xml", "wb") as mods_file:
             mods_file.write(self.serializeDocument(pretty=True))
             logger.info(
-                f"Wrote MODS for item id: {self._item.id} to file: {ark_ns}-mods.xml"
+                f"Wrote MODS for item id: {self._item.id} to file: {self._item.ark_ns}-mods.xml"
             )
 
     def add_oai_envelope(self) -> etree.Element:

--- a/oh_staff_ui/classes/OralHistoryMods.py
+++ b/oh_staff_ui/classes/OralHistoryMods.py
@@ -242,28 +242,8 @@ class OralHistoryMods(MODSv34):
                 f"Wrote MODS for item id: {self._item.id} to file: {self._item.ark_ns}-mods.xml"
             )
 
-    def add_oai_envelope(self) -> etree.Element:
 
-        record_el = etree.Element("record")
-        header_el = etree.Element("header")
-
-        id_el = etree.Element("identifier")
-        id_el.text = self._item.ark
-
-        date_el = etree.Element("datestamp")
-        date_el.text = self._item.create_date.strftime("%Y-%m-%d")
-
-        header_el.append(id_el)
-        header_el.append(date_el)
-        record_el.append(header_el)
-
-        metadata_el = etree.Element("metadata")
-        metadata_el.append(self.node)
-        record_el.append(metadata_el)
-
-        return record_el
-
-    # Extended classes to supply some additional attributes not in stock library that we use
+# Extended classes to supply some additional attributes not in stock library that we use
 
 
 class LocationOH(mods.Location):

--- a/oh_staff_ui/classes/OralHistoryMods.py
+++ b/oh_staff_ui/classes/OralHistoryMods.py
@@ -1,6 +1,8 @@
 import logging
 from django.conf import settings
+from datetime import datetime
 from pathlib import Path
+from lxml import etree
 from eulxml import xmlmap
 from eulxml.xmlmap import mods
 from eulxml.xmlmap.mods import MODSv34
@@ -242,7 +244,29 @@ class OralHistoryMods(MODSv34):
             logger.info(
                 f"Wrote MODS for item id: {self._item.id} to file: {ark_ns}-mods.xml"
             )
+    
+    def add_oai_envelope(self):
 
+        ark_ns = self._item.ark.replace("/", "-")
+
+        rec = etree.Element("record")
+        h = etree.Element("header")
+
+        i = etree.Element("identifier")
+        i.text = ark_ns
+        
+        ds = etree.Element("datestamp")
+        ds.text = self._item.create_date.strftime('%Y-%m-%d')
+        
+        h.append(i)
+        h.append(ds)
+        rec.append(h)
+
+        md = etree.Element("metadata")
+        md.append(self.node)
+        rec.append(md)
+
+        return rec
 
 # Extended classes to supply some additional attributes not in stock library that we use
 

--- a/oh_staff_ui/models.py
+++ b/oh_staff_ui/models.py
@@ -76,6 +76,10 @@ class ProjectItem(models.Model):
     def __str__(self):
         return self.title
 
+    @property
+    def ark_ns(self) -> str:
+        return self.ark.replace("/", "-")
+
     class Meta:
         indexes = [
             models.Index(fields=["ark"]),

--- a/oh_staff_ui/tests.py
+++ b/oh_staff_ui/tests.py
@@ -1184,7 +1184,7 @@ class ModsTestCase(TestCase):
         ohmods = self.get_mods_from_interview_item()
 
         ohmods_from_string = load_xmlobject_from_string(
-            ohmods.serializeDocument(), mods.MODS
+            ohmods.serializeDocument(), mods.MODSv34
         )
 
         self.assertEqual(ohmods_from_string.is_valid(), True)
@@ -1197,7 +1197,7 @@ class ModsTestCase(TestCase):
         ohmods = self.get_mods_from_interview_item()
 
         ohmods_from_string = load_xmlobject_from_string(
-            ohmods.serializeDocument(), mods.MODS
+            ohmods.serializeDocument(), mods.MODSv34
         )
 
         # Assert MODS still valid as read from string

--- a/oh_staff_ui/tests.py
+++ b/oh_staff_ui/tests.py
@@ -49,6 +49,11 @@ from oh_staff_ui.models import (
 from oh_staff_ui.classes.OralHistoryFile import OralHistoryFile
 from oh_staff_ui.classes.AudioFileHandler import AudioFileHandler
 from oh_staff_ui.classes.OralHistoryMods import OralHistoryMods
+from oh_staff_ui.views_utils import (
+    get_listrecords_oai,
+    get_record_oai,
+    get_bad_arg_error_xml,
+)
 
 
 class MediaFileTestCase(TestCase):
@@ -1321,6 +1326,23 @@ class ModsTestCase(TestCase):
         # Verify file exists
         p = Path(f"{settings.MEDIA_ROOT}/{settings.OH_STATIC}/mods/{ark_ns}-mods.xml")
         self.assertTrue(p.is_file())
+
+    def test_bad_getrecord_request(self):
+        bad_response = get_bad_arg_error_xml("GetRecordWithoutIdentifier")
+        self.assertTrue(b'<error code="badArgument"/>' in bad_response)
+
+    def test_getrecord_request(self):
+        id_to_check = self.series_item.ark
+        response = get_record_oai(id_to_check)
+        id_tag = f'identifier="{id_to_check}"'
+
+        self.assertTrue(bytes(id_tag, "utf-8") in response)
+
+    def test_listrecords_request(self):
+        response = get_listrecords_oai("ListRecords")
+        self.assertTrue(
+            b'<request metadataPrefix="mods" verb="ListRecords">' in response
+        )
 
 
 class FileMetadataMigrationTestCase(SimpleTestCase):

--- a/oh_staff_ui/tests.py
+++ b/oh_staff_ui/tests.py
@@ -50,8 +50,7 @@ from oh_staff_ui.classes.OralHistoryFile import OralHistoryFile
 from oh_staff_ui.classes.AudioFileHandler import AudioFileHandler
 from oh_staff_ui.classes.OralHistoryMods import OralHistoryMods
 from oh_staff_ui.views_utils import (
-    get_listrecords_oai,
-    get_record_oai,
+    get_records_oai,
     get_bad_arg_error_xml,
 )
 
@@ -1333,13 +1332,13 @@ class ModsTestCase(TestCase):
 
     def test_getrecord_request(self):
         id_to_check = self.series_item.ark
-        response = get_record_oai(id_to_check)
+        response = get_records_oai(id_to_check)
         id_tag = f'identifier="{id_to_check}"'
 
         self.assertTrue(bytes(id_tag, "utf-8") in response)
 
     def test_listrecords_request(self):
-        response = get_listrecords_oai("ListRecords")
+        response = get_records_oai("ListRecords")
         self.assertTrue(
             b'<request metadataPrefix="mods" verb="ListRecords">' in response
         )

--- a/oh_staff_ui/tests.py
+++ b/oh_staff_ui/tests.py
@@ -1304,7 +1304,7 @@ class ModsTestCase(TestCase):
         bad_response = get_bad_arg_error_xml("GetRecordWithoutIdentifier")
         self.assertTrue(b'<error code="badArgument"/>' in bad_response)
 
-    def test_bad_getrecord_request(self):
+    def test_bad_verb_request(self):
         bad_response = get_bad_verb_error_xml("BadVerb")
         self.assertTrue(b'<error code="badVerb"/>' in bad_response)
 

--- a/oh_staff_ui/urls.py
+++ b/oh_staff_ui/urls.py
@@ -17,5 +17,8 @@ urlpatterns = [
     path("upload_file/<int:item_id>", views.upload_file, name="upload_file"),
     path("order_files/<int:item_id>", views.order_files, name="order_files"),
     path("browse/", views.browse, name="browse"),
-    path("oai/", views.oai, name="oai")
+    # To follow OAI practice, a query parameter combination is requred of either:
+    # verb=GetRecord and identifier={ark_value}
+    # verb=ListRecords
+    path("oai/", views.oai, name="oai"),
 ]

--- a/oh_staff_ui/urls.py
+++ b/oh_staff_ui/urls.py
@@ -17,4 +17,5 @@ urlpatterns = [
     path("upload_file/<int:item_id>", views.upload_file, name="upload_file"),
     path("order_files/<int:item_id>", views.order_files, name="order_files"),
     path("browse/", views.browse, name="browse"),
+    path("oai/", views.oai, name="oai")
 ]

--- a/oh_staff_ui/views.py
+++ b/oh_staff_ui/views.py
@@ -196,24 +196,23 @@ def browse(request: HttpRequest) -> HttpResponse:
     context = {"relatives": get_all_series_and_interviews()}
     return render(request, "oh_staff_ui/browse.html", context)
 
+
 def oai(request: HttpRequest) -> HttpResponse:
     try:
         # Verb is required, ark is optional
-        verb = request.GET['verb']
-        ark = request.GET.get('identifier')
-        
+        verb = request.GET["verb"]
+        ark = request.GET.get("identifier")
+
         if verb not in ("GetRecord", "ListRecords"):
             raise Exception
-        
+
         if verb == "GetRecord":
             xml_content = get_record_oai(ark)
-        
-        elif verb == "ListRecords":
-            xml_content = get_listrecords_oai()
 
-        return HttpResponse(xml_content, content_type='text/xml')
-    
+        elif verb == "ListRecords":
+            xml_content = get_listrecords_oai("ListRecords")
+
+        return HttpResponse(xml_content, content_type="text/xml")
+
     except Exception as e:
-        return HttpResponseBadRequest(); 
-    
-    
+        return HttpResponseBadRequest()

--- a/oh_staff_ui/views.py
+++ b/oh_staff_ui/views.py
@@ -25,6 +25,7 @@ from oh_staff_ui.views_utils import (
     save_sequence_data,
     get_records_oai,
     get_bad_arg_error_xml,
+    get_bad_verb_error_xml,
 )
 
 logger = logging.getLogger(__name__)
@@ -198,26 +199,22 @@ def browse(request: HttpRequest) -> HttpResponse:
 
 
 def oai(request: HttpRequest) -> HttpResponse:
-    try:
-        # Verb is required, ark is optional
-        verb = request.GET["verb"]
-        ark = request.GET.get("identifier")
 
-        if verb not in ("GetRecord", "ListRecords"):
-            raise ValueError
+    # Verb is required, ark is optional
+    verb = request.GET["verb"]
+    ark = request.GET.get("identifier")
+    req_url = request.build_absolute_uri("?")
 
-        req_url = request.build_absolute_uri("?")
+    if verb not in ("GetRecord", "ListRecords"):
+        xml_content = get_bad_verb_error_xml(verb, req_url)
 
-        if verb == "GetRecord":
-            if ark:
-                xml_content = get_records_oai(verb, ark, req_url)
-            else:
-                xml_content = get_bad_arg_error_xml(verb, req_url)
+    if verb == "GetRecord":
+        if ark:
+            xml_content = get_records_oai(verb, ark, req_url)
+        else:
+            xml_content = get_bad_arg_error_xml(verb, req_url)
 
-        elif verb == "ListRecords":
-            xml_content = get_records_oai("ListRecords", req_url=req_url)
+    elif verb == "ListRecords":
+        xml_content = get_records_oai("ListRecords", req_url=req_url)
 
-        return HttpResponse(xml_content, content_type="text/xml")
-
-    except ValueError:
-        return HttpResponseBadRequest()
+    return HttpResponse(xml_content, content_type="text/xml")

--- a/oh_staff_ui/views.py
+++ b/oh_staff_ui/views.py
@@ -23,8 +23,7 @@ from oh_staff_ui.views_utils import (
     run_process_file_command,
     save_all_item_data,
     save_sequence_data,
-    get_listrecords_oai,
-    get_record_oai,
+    get_records_oai,
     get_bad_arg_error_xml,
 )
 
@@ -211,12 +210,12 @@ def oai(request: HttpRequest) -> HttpResponse:
 
         if verb == "GetRecord":
             if ark:
-                xml_content = get_record_oai(ark, req_url=req_url)
+                xml_content = get_records_oai(verb, ark, req_url)
             else:
                 xml_content = get_bad_arg_error_xml(verb, req_url)
 
         elif verb == "ListRecords":
-            xml_content = get_listrecords_oai("ListRecords", req_url=req_url)
+            xml_content = get_records_oai("ListRecords", req_url=req_url)
 
         return HttpResponse(xml_content, content_type="text/xml")
 

--- a/oh_staff_ui/views.py
+++ b/oh_staff_ui/views.py
@@ -7,6 +7,7 @@ from django.shortcuts import redirect, render
 from django.contrib.auth.decorators import login_required
 from django.http.request import HttpRequest  # for code completion
 from django.http.response import HttpResponse  # for code completion
+from django.http.response import HttpResponseBadRequest
 from oh_staff_ui.forms import (
     FileUploadForm,
     ProjectItemForm,
@@ -22,6 +23,8 @@ from oh_staff_ui.views_utils import (
     run_process_file_command,
     save_all_item_data,
     save_sequence_data,
+    get_listrecords_oai,
+    get_record_oai,
 )
 
 logger = logging.getLogger(__name__)
@@ -192,3 +195,25 @@ def order_files(request: HttpRequest, item_id: int) -> HttpResponse:
 def browse(request: HttpRequest) -> HttpResponse:
     context = {"relatives": get_all_series_and_interviews()}
     return render(request, "oh_staff_ui/browse.html", context)
+
+def oai(request: HttpRequest) -> HttpResponse:
+    try:
+        # Verb is required, ark is optional
+        verb = request.GET['verb']
+        ark = request.GET.get('identifier')
+        
+        if verb not in ("GetRecord", "ListRecords"):
+            raise Exception
+        
+        if verb == "GetRecord":
+            xml_content = get_record_oai(ark)
+        
+        elif verb == "ListRecords":
+            xml_content = get_listrecords_oai()
+
+        return HttpResponse(xml_content, content_type='text/xml')
+    
+    except Exception as e:
+        return HttpResponseBadRequest(); 
+    
+    

--- a/oh_staff_ui/views.py
+++ b/oh_staff_ui/views.py
@@ -205,22 +205,18 @@ def oai(request: HttpRequest) -> HttpResponse:
         ark = request.GET.get("identifier")
 
         if verb not in ("GetRecord", "ListRecords"):
-            raise Exception
+            raise ValueError
 
-        print(ark)
         if verb == "GetRecord":
             if ark:
                 xml_content = get_record_oai(ark)
             else:
-                print("blah")
                 xml_content = get_bad_arg_error_xml(verb)
 
         elif verb == "ListRecords":
             xml_content = get_listrecords_oai("ListRecords")
 
-        # xml_content=""
-
         return HttpResponse(xml_content, content_type="text/xml")
 
-    except Exception as e:
+    except ValueError:
         return HttpResponseBadRequest()

--- a/oh_staff_ui/views.py
+++ b/oh_staff_ui/views.py
@@ -7,7 +7,6 @@ from django.shortcuts import redirect, render
 from django.contrib.auth.decorators import login_required
 from django.http.request import HttpRequest  # for code completion
 from django.http.response import HttpResponse  # for code completion
-from django.http.response import HttpResponseBadRequest
 from oh_staff_ui.forms import (
     FileUploadForm,
     ProjectItemForm,

--- a/oh_staff_ui/views.py
+++ b/oh_staff_ui/views.py
@@ -25,6 +25,7 @@ from oh_staff_ui.views_utils import (
     save_sequence_data,
     get_listrecords_oai,
     get_record_oai,
+    get_bad_arg_error_xml,
 )
 
 logger = logging.getLogger(__name__)
@@ -206,11 +207,18 @@ def oai(request: HttpRequest) -> HttpResponse:
         if verb not in ("GetRecord", "ListRecords"):
             raise Exception
 
+        print(ark)
         if verb == "GetRecord":
-            xml_content = get_record_oai(ark)
+            if ark:
+                xml_content = get_record_oai(ark)
+            else:
+                print("blah")
+                xml_content = get_bad_arg_error_xml(verb)
 
         elif verb == "ListRecords":
             xml_content = get_listrecords_oai("ListRecords")
+
+        # xml_content=""
 
         return HttpResponse(xml_content, content_type="text/xml")
 

--- a/oh_staff_ui/views.py
+++ b/oh_staff_ui/views.py
@@ -207,14 +207,16 @@ def oai(request: HttpRequest) -> HttpResponse:
         if verb not in ("GetRecord", "ListRecords"):
             raise ValueError
 
+        req_url = request.build_absolute_uri("?")
+
         if verb == "GetRecord":
             if ark:
-                xml_content = get_record_oai(ark)
+                xml_content = get_record_oai(ark, req_url=req_url)
             else:
                 xml_content = get_bad_arg_error_xml(verb)
 
         elif verb == "ListRecords":
-            xml_content = get_listrecords_oai("ListRecords")
+            xml_content = get_listrecords_oai("ListRecords", req_url=req_url)
 
         return HttpResponse(xml_content, content_type="text/xml")
 

--- a/oh_staff_ui/views.py
+++ b/oh_staff_ui/views.py
@@ -213,7 +213,7 @@ def oai(request: HttpRequest) -> HttpResponse:
             if ark:
                 xml_content = get_record_oai(ark, req_url=req_url)
             else:
-                xml_content = get_bad_arg_error_xml(verb)
+                xml_content = get_bad_arg_error_xml(verb, req_url)
 
         elif verb == "ListRecords":
             xml_content = get_listrecords_oai("ListRecords", req_url=req_url)

--- a/oh_staff_ui/views_utils.py
+++ b/oh_staff_ui/views_utils.py
@@ -538,11 +538,11 @@ def get_request_element(
     return e_req
 
 
-def get_bad_arg_error_xml(verb: str) -> str:
+def get_bad_arg_error_xml(verb: str, req_url: str = None) -> str:
     oai_envelope = get_oai_envelope()
 
     oai_envelope.append(get_response_date_element())
-    oai_envelope.append(get_request_element(verb))
+    oai_envelope.append(get_request_element(verb, req_url=req_url))
 
     error_str = f"""<error code="badArgument"/>"""
     error_elem = etree.fromstring(error_str)

--- a/oh_staff_ui/views_utils.py
+++ b/oh_staff_ui/views_utils.py
@@ -471,8 +471,10 @@ def run_process_file_command(
     # To be safe, explicitly close this one when done.
     connection.close()
 
+
 def get_record_oai(ark: str = None) -> str:
     return get_listrecords_oai("GetRecord", ark)
+
 
 def get_listrecords_oai(verb: str, ark: str = None) -> str:
 
@@ -494,11 +496,6 @@ def wrap_oai_content(xml_element, verb: str, ark: str) -> str:
     oai_tree = get_oai_envelope()
     oai_tree.append(get_response_date_element())
     oai_tree.append(get_request_element(verb, ark))
-
-    # if ark_ns:
-    #    e_req.set("identifier", ark_ns)
-
-    # oai_tree.append(e_req)
     oai_tree.append(xml_element)
 
     return etree.tostring(oai_tree)

--- a/oh_staff_ui/views_utils.py
+++ b/oh_staff_ui/views_utils.py
@@ -540,14 +540,34 @@ def get_bad_arg_error_xml(verb: str, req_url: str = None) -> str:
     http://www.openarchives.org/OAI/openarchivesprotocol.html#ErrorConditions
 
     """
+    error_elem = etree.fromstring('<error code="badArgument"/>')
 
+    return wrap_oai_error(verb, error_elem, req_url)
+
+
+def get_bad_verb_error_xml(verb: str, req_url: str = None) -> str:
+    """If a missing or bad verb is submitted with a request, OAI best practice is to
+    return an OAI error response rather than returning a HTTP error code.
+
+    http://www.openarchives.org/OAI/openarchivesprotocol.html#ErrorConditions
+
+    """
+    error_elem = etree.fromstring('<error code="badVerb"/>')
+
+    return wrap_oai_error(verb, error_elem, req_url)
+
+
+def wrap_oai_error(verb: str, error_elem: etree.Element, req_url: str = None) -> str:
+    """OAI best practice is to return an OAI error response rather than returning a
+    HTTP error code in certain cases.
+
+    http://www.openarchives.org/OAI/openarchivesprotocol.html#ErrorConditions
+
+    """
     oai_envelope = get_oai_envelope()
 
     oai_envelope.append(get_response_date_element())
     oai_envelope.append(get_request_element(verb, req_url=req_url))
-
-    error_elem = etree.fromstring('<error code="badArgument"/>')
-
     oai_envelope.append(error_elem)
 
     return etree.tostring(oai_envelope)

--- a/oh_staff_ui/views_utils.py
+++ b/oh_staff_ui/views_utils.py
@@ -491,7 +491,7 @@ def get_listrecords_oai(verb: str, ark: str = None) -> str:
     return wrap_oai_content(verb_element, verb, ark)
 
 
-def wrap_oai_content(xml_element, verb: str, ark: str) -> str:
+def wrap_oai_content(xml_element: etree.Element, verb: str, ark: str) -> str:
 
     oai_tree = get_oai_envelope()
     oai_tree.append(get_response_date_element())


### PR DESCRIPTION
This implements:
- SYS-1308 : Add OAI envelope
- SYS-1310 : Add GetRecord url option
- SYS-1311 : Add ListRecords url option

This replaces the core functionality of providing OH content via an OAI like endpoint, in order to deprecate the fragile current dldataprovider app and prevent the need for use of a stand alone OAI provider. 

Some feedback is appreciated, as some of the django best practices have not been followed, rather the OAI format for urls, but since there is only 1 client, I think we have some flexibility here.

A url parameter `verb` is required in the query string, this is the only required parameter, though it does not make sense without an `identifier` parameter as well for `GetRecord`

Example of use in the previous system:
https://webservices.library.ucla.edu/dldataprovider/oai2_0.do?verb=GetRecord&identifier=21198-zz002kppdz&metadataPrefix=mods

Matching equivalent in the new application:
http://localhost:8000/oai/?verb=GetRecord&identifier=21198-zz002kppdz

For all completed records, previous system:
https://webservices.library.ucla.edu/dldataprovider/oai2_0.do?verb=ListRecords&set=oralhistory&metadataPrefix=mods

Matching equivalent in new application:
http://localhost:8000/oai/?verb=ListRecords

Since the only metadata standard we are supporting is mods, and the only set we have is oral history, these parameters have been dropped from being required.

An ark that is empty or returns no result is returned with empty xml, consistent with the previous application.

Because only other machines should be reading this, any errors or exceptions encountered result in a `HttpResponseBadRequest()` rather than a user readable message.

Please review and provide feedback for improvement suggestions, particularly around bad input or error handling.

 ---
Feedback notes:

Valid behavior should be as follows when using:

A `verb` parameter must be supplied, and must be either `GetRecord` or `ListRecords`, any other values for verb, or absence of a verb  should return HttpResponseBadRequest()

If `verb=GetRecord` an `identifier` parameter must be supplied. If an `identifier` parameter is not supplied, an xml response will be returned but with `<error code="badArgument"/>` inside the `OAI` tag

If a `identifier` is supplied, if an `ark` is found for that value, a MODS record is returned wrapped in OAI elements. If no `ProjectItem` is found matching this `ark`, an empty `GetRecord` element is returned.

A test for these 3 cases (`GetRecord` with and without `identifier`, `ListRecords`) has been added.

Additional changes:

- `ark_ns` property added to `ProjectItem` for returning `ark`s with a dash replacing slash 
- Removed unused import in `OralHistoryMods`
- Changed behavior of `GetRecord` in case of no `identifier`
- Improved variable names in `OralHistoryMods`
- Added comments to `urls.py` to explain query parameter expectations of `/oai`
- Moved oai functions out of `OralHistoryMods` and into `views_util`
- Added more specific exception in `views` for `oai` path

---

Feedback notes continued

The feedback below has been incorporated and some more 'not ideal' changes to tests to get through a blocker.

- Addressing the http error code vs OAI response inconsistency, the oai view now does not return http error codes previous errors but follows the best practices requested for the errors encountered during an OAI request:
http://www.openarchives.org/OAI/openarchivesprotocol.html#ErrorConditions

To confirm error conditions:
- BadVerb (not GetRecord or ListRecords): http://localhost:8000/oai/?verb=GetRecordz&21198/zz000905jr
- BadArgument (Missing required parameter) : http://localhost:8000/oai/?verb=GetRecord

- The duplicate and confusing methods for `get_record` and `get_listrecords` have been squashed into 1 `get_records_oai` method per suggestion
- Inconsistencies with method parameters updated
- Unused imports removed

Tests:
- Some tests reworked to account for new error values
- References to `MODS.is_valid()` removed for now until a reliable method of accessing a remote XSD (or alternative) is implemented


