### PR TITLE
SYS-1369: Increase form field limit for description text

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,3 +278,12 @@ $ docker-exec exec django python manage.py shell
 (1, {'oh_staff_ui.MediaFile': 1})
 ```
 Deleting a `MediaFile` object does _*not*_ currently delete any `FileField` object associated with it, so it's necessary to do a `file.delete()` first.
+
+#### Preparing a release
+
+Our deployment system is triggered by changes to the Helm chart.  Typically, this is done by incrementing `image:tag` (on or near line 9) in `charts/prod-ohstaff-values.yaml`.  We use a simple [semantic versioning](https://semver.org/) system:
+* Bug fixes: update patch level (e.g., `v1.0.1` to `v1.0.2`)
+* Backward compatible functionality changes: update minor level (e.g., `v1.0.1` to `v1.1.0`)
+* Breaking changes: update major level (e.g., `v1.0.1` to `v2.0.0`)
+
+In addition to updating version in the Helm chart, update the Release Notes in `oh_staff_ui/templates/oh_staff_ui/release_notes.html`.  Put the latest changes first, following the established format.

--- a/charts/prod-ohstaff-values.yaml
+++ b/charts/prod-ohstaff-values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: uclalibrary/oral-history-staff-ui
-  tag: v1.0.1
+  tag: v1.0.2
   pullPolicy: Always
 
 nameOverride: ""

--- a/docker-compose_REMOTE.yml
+++ b/docker-compose_REMOTE.yml
@@ -9,6 +9,9 @@ services:
       # - .docker-compose_db.env
       # Info for connection to production database via ssh tunnel
       - .docker-compose_secrets.env
+    environment:
+      # Force the environment to be production, when connecting from Docker in this way.
+      - DJANGO_RUN_ENV=prod
     ports: 
       # Variables here must be set in environment, or in .env - not in any env_file
       - "8000:8000"

--- a/oh_staff_ui/forms.py
+++ b/oh_staff_ui/forms.py
@@ -244,7 +244,7 @@ class DescriptionForm(forms.Form):
     )
     value = forms.CharField(
         required=True,
-        max_length=1024,
+        max_length=8000,
         widget=forms.Textarea(attrs={"cols": 98, "rows": 3}),
     )
 

--- a/oh_staff_ui/templates/oh_staff_ui/base.html
+++ b/oh_staff_ui/templates/oh_staff_ui/base.html
@@ -22,6 +22,7 @@
         <li><a href="/browse/">Browse Series</a></li>
         <li><a href="/admin/">Admin (Metadata Configuration)</a></li>
         <li><a href="/logs/">Logs</a></li>
+        <li><a href="/release_notes/">Release Notes</a></li>
         <li><a href="/admin/logout/">Logout</a></li>
     </ul>
     <br>

--- a/oh_staff_ui/templates/oh_staff_ui/release_notes.html
+++ b/oh_staff_ui/templates/oh_staff_ui/release_notes.html
@@ -1,0 +1,30 @@
+{% extends 'oh_staff_ui/base.html' %}
+
+{% block content %}
+<h3>Release Notes</h3>
+<hr/>
+
+<h4>1.0.2</h4>
+<p><i>August 8, 2023</i></p>
+<ul>
+    <li>Increased Description form field limit to 8000 characters, matching database limit.</li>
+    <li>Changed local configuration to prevent fixtures from loading when connecting from Docker to production database.</li>
+    <li>Added release notes.</li>
+</ul>
+
+<h4>1.0.1</h4>
+<p><i>June 29, 2023</i></p>
+<ul>
+    <li>Deployed OAI changes to allow harvesting for public site.</li>
+</ul>
+
+
+<h4>1.0.0</h4>
+<p><i>June 12, 2023</i></p>
+<ul>
+    <li>
+        First production release.
+    </li>
+</ul>
+
+{% endblock %}

--- a/oh_staff_ui/urls.py
+++ b/oh_staff_ui/urls.py
@@ -21,4 +21,5 @@ urlpatterns = [
     # verb=GetRecord and identifier={ark_value}
     # verb=ListRecords
     path("oai/", views.oai, name="oai"),
+    path("release_notes/", views.release_notes, name="release_notes"),
 ]

--- a/oh_staff_ui/views.py
+++ b/oh_staff_ui/views.py
@@ -198,7 +198,6 @@ def browse(request: HttpRequest) -> HttpResponse:
 
 
 def oai(request: HttpRequest) -> HttpResponse:
-
     # Verb is required, ark is optional
     verb = request.GET["verb"]
     ark = request.GET.get("identifier")
@@ -217,3 +216,7 @@ def oai(request: HttpRequest) -> HttpResponse:
         xml_content = get_records_oai("ListRecords", req_url=req_url)
 
     return HttpResponse(xml_content, content_type="text/xml")
+
+
+def release_notes(request: HttpRequest) -> HttpResponse:
+    return render(request, "oh_staff_ui/release_notes.html")


### PR DESCRIPTION
Implements [SYS-1369](https://jira.library.ucla.edu/browse/SYS-1369), while bringing two other minor issues along:
* [SYS-1345: Prevent fixtures from being reloaded in production](https://jira.library.ucla.edu/browse/SYS-1345)
* [SYS-1234: Display application version (via release notes)](https://jira.library.ucla.edu/browse/SYS-1234)

This PR fixes a problem where the item metadata form limited Description text entry to 1024 characters, instead of allowing the full 8000 characters the model supports.  Migrated Description data includes values nearly 4000 characters long, and Oral History staff occasionally need to add very long tables of contents.

Since this was a very minor technical change which needed to be done, I combined it with two other minor issues which might otherwise not get done.
1) Running the local Docker environment while connecting to the remote production database would cause fixtures to be (re)loaded, which could restore the corresponding production data to its default state.  This was fixed by changing `docker-compose_REMOTE.yml` to set `DJANGO_RUN_ENV=prod`, explicitly using the production environment.
2) There was no easy way to see the deployed application version, and no central location for release notes telling users what had changed.  I combined these by adding `/release_notes/`, which include both version and notes.  I also added a note to `README.md` to document the release process.  There's also a link to "Release Notes" in the application's top menu bar.

#### Testing
There's not much to test.  Start the application, create or edit a record and confirm that long text can be added to the Description field.  http://127.0.0.1:8000/item/10334 is an existing example which has about 3800 characters; copy and paste it into the field again to verify 7500+ characters can be entered, stored and displayed.

Visit http://127.0.0.1:8000/release_notes/ to confirm that release notes display, including version information.


