### PR TITLE
SYS-1416: Fix audio_submaster bug

### DIFF
--- a/charts/prod-ohstaff-values.yaml
+++ b/charts/prod-ohstaff-values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: uclalibrary/oral-history-staff-ui
-  tag: v1.0.2
+  tag: v1.0.3
   pullPolicy: Always
 
 nameOverride: ""

--- a/oh_staff_ui/classes/AudioFileHandler.py
+++ b/oh_staff_ui/classes/AudioFileHandler.py
@@ -98,7 +98,7 @@ class AudioFileHandler(BaseFileHandler):
             submaster_file = OralHistoryFile(
                 item_id=self._master_file.item.id,
                 file_name=submaster_file_name,
-                file_type=MediaFileType.objects.get(file_code="audio_master"),
+                file_type=MediaFileType.objects.get(file_code="audio_submaster"),
                 file_use="submaster",
                 request=self._master_file.request,
             )

--- a/oh_staff_ui/templates/oh_staff_ui/release_notes.html
+++ b/oh_staff_ui/templates/oh_staff_ui/release_notes.html
@@ -4,6 +4,12 @@
 <h3>Release Notes</h3>
 <hr/>
 
+<h4>1.0.3</h4>
+<p><i>October 1, 2023</i></p>
+<ul>
+    <li>Fixed bug which set the wrong media file type on submaster audio files.</li>
+</ul>
+
 <h4>1.0.2</h4>
 <p><i>August 8, 2023</i></p>
 <ul>

--- a/oh_staff_ui/tests.py
+++ b/oh_staff_ui/tests.py
@@ -164,6 +164,10 @@ class MediaFileTestCase(TestCase):
         self.assertEqual(MediaFile.objects.count(), 2)
         # Confirm master is parent of submaster.
         self.assertEqual(master.media_file, submaster.parent)
+        # Confirm submaster has correct file type.
+        self.assertEqual(
+            submaster.file_type, MediaFileType.objects.get(file_code="audio_submaster")
+        )
 
     def test_duplicate_files_not_allowed(self):
         file1 = self.create_master_audio_file()


### PR DESCRIPTION
Fixed [SYS-1416](https://uclalibrary.atlassian.net/browse/SYS-1416).
Tagged as version `v1.0.3` for release.

This PR fixes a bug in the `AudioFileHandler` class, which incorrectly set the `MediaFileType` of audio submaster files as masters instead.  It also adds a test to confirm this.


[SYS-1416]: https://uclalibrary.atlassian.net/browse/SYS-1416?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ