### PR TITLE
Combined title and alttitle generation to resolve bug

### DIFF
--- a/charts/prod-ohstaff-values.yaml
+++ b/charts/prod-ohstaff-values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: uclalibrary/oral-history-staff-ui
-  tag: v1.0.3
+  tag: v1.0.4
   pullPolicy: Always
 
 nameOverride: ""
@@ -26,13 +26,13 @@ ingress:
     cert-manager.io/cluster-issuer: sectigo-acme-clusterissuer
     kubernetes.io/tls-acme: "true"
   hosts:
-    - host: 'oh-staff.library.ucla.edu'
+    - host: "oh-staff.library.ucla.edu"
       paths:
         - "/"
   tls:
-  - secretName: oh-staff-tls
-    hosts:
-      - oh-staff.library.ucla.edu
+    - secretName: oh-staff-tls
+      hosts:
+        - oh-staff.library.ucla.edu
 
 django:
   env:
@@ -62,7 +62,7 @@ django:
 
   externalSecrets:
     enabled: "true"
-    annotations: 
+    annotations:
       argocd.argoproj.io/sync-wave: "-3"
     env:
       # Application database used by django

--- a/oh_staff_ui/classes/OralHistoryMods.py
+++ b/oh_staff_ui/classes/OralHistoryMods.py
@@ -30,7 +30,7 @@ class OralHistoryMods(MODSv34):
         self.populate_fields()
 
     def populate_fields(self):
-        self._populate_alttitle()
+        self._populate_titles()
         self._populate_create_date()
         self._populate_description()
         self._populate_format()
@@ -40,18 +40,16 @@ class OralHistoryMods(MODSv34):
         self._populate_relation()
         self._populate_rights()
         self._populate_subjects()
-        self._populate_title()
         self._populate_constituent_audio()
         self._populate_narrator_image()
         self._populate_interview_content()
         self._populate_series_content()
 
-    def _populate_title(self):
-        self.title = self._item.title
+    def _populate_titles(self):
+        # create_title_info() should not be called, otherwise an empty duplicate title
+        # container will be created, overwriting previous titles
+        self.title_info_list.append(mods.TitleInfo(title=self._item.title))
 
-    def _populate_alttitle(self):
-        # All alternate titles are assigned mods type of "alternate", no matter the database assignment
-        self.create_title_info()
         alt_titles = AltTitle.objects.filter(item=self._item)
         for alt_title in alt_titles:
             self.title_info_list.append(

--- a/oh_staff_ui/templates/oh_staff_ui/release_notes.html
+++ b/oh_staff_ui/templates/oh_staff_ui/release_notes.html
@@ -4,6 +4,12 @@
 <h3>Release Notes</h3>
 <hr/>
 
+<h4>1.0.4</h4>
+<p><i>October 9, 2023</i></p>
+<ul>
+    <li>Fixed bug when both a title and alternate title exists, resulting in an incorrect MODS record.</li>
+</ul>
+
 <h4>1.0.3</h4>
 <p><i>October 1, 2023</i></p>
 <ul>


### PR DESCRIPTION
We had reports of cases when an item had both a title and an alternate title, the title would not be generated correctly.

This turned out to be an issue of title and alt title creation ordering in the MODS creation process and inappropriately creating an additional `titleInfo` container.

To test:

All existing tests should continue to pass

Confirm item with alt title is generated correctly:

http://localhost:8000/oai/?verb=GetRecord&identifier=21198/zz0008zd21
```
<mods:titleInfo>
<mods:title>Interview of Friedrich A. Von Hayek</mods:title>
</mods:titleInfo>
<mods:titleInfo type="alternative">
<mods:title>Nobel Prize-Winning Economist</mods:title>
</mods:titleInfo>
```

Confirm item without alt title is also generated correctly:
http://localhost:8000/oai/?verb=GetRecord&identifier=21198/zz002kppdz
```
<mods:titleInfo>
<mods:title>Interview of Paul Pickowicz</mods:title>
</mods:titleInfo>
```

Verify an existing incorrect record from production:
https://oh-staff.library.ucla.edu/oai/?verb=GetRecord&identifier=21198/zz0009025m
```
<mods:titleInfo/>
<mods:titleInfo type="alternative">
<mods:title>Interview of Gilbert Lindsay</mods:title>
</mods:titleInfo>
```

The local correct generation:
http://localhost:8000/oai/?verb=GetRecord&identifier=21198/zz0009025m
```
<mods:titleInfo>
<mods:title>Interview of Gilbert Lindsay</mods:title>
</mods:titleInfo>
<mods:titleInfo type="alternative">
<mods:title>unknown title</mods:title>
</mods:titleInfo>
```

Note in the incorrect version, the actual title is labeled  as alternate, and the actual alternate title is absent. The actual data for the alt title is `unknown title` in the database.
