### PR TITLE
SYS-1426: Include 'Completed with minimal metadata' items in OAI feed

### DIFF
--- a/charts/prod-ohstaff-values.yaml
+++ b/charts/prod-ohstaff-values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: uclalibrary/oral-history-staff-ui
-  tag: v1.0.4
+  tag: v1.0.5
   pullPolicy: Always
 
 nameOverride: ""

--- a/oh_staff_ui/templates/oh_staff_ui/release_notes.html
+++ b/oh_staff_ui/templates/oh_staff_ui/release_notes.html
@@ -4,6 +4,12 @@
 <h3>Release Notes</h3>
 <hr/>
 
+<h4>1.0.5</h4>
+<p><i>October 12, 2023</i></p>
+<ul>
+    <li>Fixed bug preventing "Completed with minimal metadata" records from being published via OAI.</li>
+</ul>
+
 <h4>1.0.4</h4>
 <p><i>October 9, 2023</i></p>
 <ul>

--- a/oh_staff_ui/views_utils.py
+++ b/oh_staff_ui/views_utils.py
@@ -472,8 +472,10 @@ def run_process_file_command(
 
 
 def get_records_oai(verb: str, ark: str = None, req_url: str = None) -> str:
-
-    pi_set = ProjectItem.objects.filter(status__status__iexact="completed")
+    # Only items with these statuses should be published via OAI.
+    pi_set = ProjectItem.objects.filter(
+        status__status__in=["Completed", "Completed with minimal metadata"]
+    )
 
     if ark:
         pi_set = pi_set.filter(ark=ark)
@@ -489,7 +491,6 @@ def get_records_oai(verb: str, ark: str = None, req_url: str = None) -> str:
 def wrap_oai_content(
     xml_element: etree.Element, verb: str, ark: str, req_url: str
 ) -> str:
-
     oai_tree = get_oai_envelope()
     oai_tree.append(get_response_date_element())
     oai_tree.append(get_request_element(verb, ark, req_url))
@@ -500,9 +501,9 @@ def wrap_oai_content(
 
 def get_oai_envelope() -> etree.Element:
     oai_envelope = """
-            <OAI-PMH xmlns="http://www.openarchives.org/OAI/2.0/" 
-                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
-                xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ 
+            <OAI-PMH xmlns="http://www.openarchives.org/OAI/2.0/"
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/
                 http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd" />
             """
     oai_tree = etree.fromstring(oai_envelope)
@@ -511,7 +512,6 @@ def get_oai_envelope() -> etree.Element:
 
 
 def get_response_date_element() -> etree.Element:
-
     date_el = etree.Element("responseDate")
     date_el.text = datetime.now().strftime("%Y-%m-%dT%H:%M:%SZ")
 
@@ -521,7 +521,6 @@ def get_response_date_element() -> etree.Element:
 def get_request_element(
     verb: str, ark: str = None, req_url: str = None
 ) -> etree.Element:
-
     req = f"""<request metadataPrefix="mods">{req_url}</request>"""
 
     e_req = etree.fromstring(req)
@@ -574,7 +573,6 @@ def wrap_oai_error(verb: str, error_elem: etree.Element, req_url: str = None) ->
 
 
 def add_oai_envelope_to_mods(ohmods: OralHistoryMods) -> etree.Element:
-
     record_el = etree.Element("record")
     header_el = etree.Element("header")
 


### PR DESCRIPTION
Implements [SYS-1426](https://uclalibrary.atlassian.net/browse/SYS-1426).  Tagged as `v1.0.5` for release.

This PR fixes a bug which prevented items with status `Completed with minimal metadata` from being published via OAI.

There's also a little reformatting / cleanup of `views_utils.py` to make flake8/black happy.


[SYS-1426]: https://uclalibrary.atlassian.net/browse/SYS-1426?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ