### PR TITLE
SYS-1529: Prevent Sealed item information from being included in OAI feed.

### DIFF
--- a/charts/prod-ohstaff-values.yaml
+++ b/charts/prod-ohstaff-values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: uclalibrary/oral-history-staff-ui
-  tag: v1.0.5
+  tag: v1.0.6
   pullPolicy: Always
 
 nameOverride: ""

--- a/oh_staff_ui/classes/OralHistoryMods.py
+++ b/oh_staff_ui/classes/OralHistoryMods.py
@@ -156,8 +156,11 @@ class OralHistoryMods(MODSv34):
             self.origin_info.created.append(mods.DateCreated(date=date))
 
     def _populate_constituent_audio(self):
-        # For each child of the item, get submaster audio MediaFile
-        for child in ProjectItem.objects.filter(parent=self._item).order_by("sequence"):
+        # For each Completed child of the item, get submaster audio MediaFile
+        for child in ProjectItem.objects.filter(
+            parent=self._item,
+            status__status__in=["Completed", "Completed with minimal metadata"],
+        ).order_by("sequence"):
             for audiofile in MediaFile.objects.filter(
                 item=child, file_type__file_code="audio_submaster"
             ):

--- a/oh_staff_ui/templates/oh_staff_ui/release_notes.html
+++ b/oh_staff_ui/templates/oh_staff_ui/release_notes.html
@@ -4,6 +4,12 @@
 <h3>Release Notes</h3>
 <hr/>
 
+<h4>1.0.6</h4>
+<p><i>February 15, 2024</i></p>
+<ul>
+    <li>Fixed bug which allowed non-Completed relatedItem metadata to be included in MODS records via OAI.</li>
+</ul>
+
 <h4>1.0.5</h4>
 <p><i>October 12, 2023</i></p>
 <ul>


### PR DESCRIPTION
Implement [SYS-1529](https://uclalibrary.atlassian.net/browse/SYS-1529).  Bumps version to `v1.0.6` for deployment.

This PR fixes a bug which allowed non-Completed File-level item metadata, including media URLs, to be included in the OAI feed.  For Sealed items which must not be published, this could expose sensitive information.

The fix itself adds a check on item status to `OralHistoryMods._populate_constituent_audio()`, to allow only Completed File-level item metadata to be added to the MODS record.

There also are several new tests which verify that Completed items are included, and non-Completed (specifically Sealed) items and metadata are excluded.  Since these tests require checking specific XML data, several utility test methods were added to make it easier to access the relevant data.  One existing utility test method, `ModsTestCase.get_mods_from_item_type()`, needed to be changed to account for some persistent test data being changed in a way which broke some existing tests.

### Testing

There now are 89 tests, all passing.

For manual testing locally, try these:
* [Interview of June Wayne (2011)](http://127.0.0.1:8000/oai/?verb=GetRecord&identifier=21198/zz00292rws): a Completed interview with 7 Completed audios, though only sessions 1-6 have audio media files.  Those 6 sessions should be in the OAI MODS record.  Session 7 should not, since it has no audio media files, just XML files.  "Sealed session 7", a sealed transcript, and an "In progress" legal agreement also are not included.
* [SEALED SESSION 7 (6/5/2011)](http://127.0.0.1:8000/oai/?verb=GetRecord&identifier=21198/zz002k637w): the Sealed Session 7 File-level item for the interview above.  The OAI MODS for this should just be the envelope, with no records.


[SYS-1529]: https://uclalibrary.atlassian.net/browse/SYS-1529?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ