### PR TITLE
Timed log attribute added for TEI XML transcripts with test

### DIFF
--- a/charts/prod-ohstaff-values.yaml
+++ b/charts/prod-ohstaff-values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: uclalibrary/oral-history-staff-ui
-  tag: v1.0.6
+  tag: v1.0.7
   pullPolicy: Always
 
 nameOverride: ""

--- a/oh_staff_ui/classes/OralHistoryMods.py
+++ b/oh_staff_ui/classes/OralHistoryMods.py
@@ -210,14 +210,22 @@ class OralHistoryMods(MODSv34):
         ).order_by("sequence"):
             if f.file_url != "":
                 label = fc_to_label[f.file_type.file_code]
+                usage = ""
 
                 if f.file_type.file_code == "text_master_transcript":
                     if f.file_name_only.endswith(".html"):
                         label = f"{label} (Printable Version)"
                     else:
                         label = f"{label} (TEI/P5 XML)"
+                        usage = "timed log"
 
-                self.locations.append(LocationOH(url=f.file_url, label=label))
+                # If our MediaFile is TEI/P5 XML, a usage attribute is populated and should be included
+                if usage:
+                    self.locations.append(
+                        LocationOH(url=f.file_url, label=label, usage=usage)
+                    )
+                else:
+                    self.locations.append(LocationOH(url=f.file_url, label=label))
 
     def _populate_series_content(self):
         p = self._item.parent

--- a/oh_staff_ui/templates/oh_staff_ui/release_notes.html
+++ b/oh_staff_ui/templates/oh_staff_ui/release_notes.html
@@ -4,6 +4,12 @@
 <h3>Release Notes</h3>
 <hr/>
 
+<h4>1.0.7</h4>
+<p><i>March 14, 2024</i></p>
+<ul>
+    <li>Added "timed log" attribute to OAI MODS records for TEI XML transcripts.</li>
+</ul>
+
 <h4>1.0.6</h4>
 <p><i>February 15, 2024</i></p>
 <ul>

--- a/oh_staff_ui/tests.py
+++ b/oh_staff_ui/tests.py
@@ -1142,6 +1142,13 @@ class ModsTestCase(TestCase):
             original_file_name="FAKE_TIMED_LOG",
             file="oh_static/text/submasters/fake-abcdef-2-master.xml",
         )
+        MediaFile.objects.create(
+            created_by=cls.user,
+            file_type=MediaFileType.objects.get(file_code="text_master_transcript"),
+            item=cls.audio_item,
+            original_file_name="FAKE_TEI_TIMED_LOG",
+            file="oh_static/text/submasters/fake-abcdef-2-master-tei.xml",
+        )
 
     # Utility methods to return MODS specific to item type
     def get_mods_from_audio_item(self):
@@ -1342,6 +1349,17 @@ class ModsTestCase(TestCase):
         self.assertTrue(
             b'<mods:relatedItem type="series">' not in ohmods.serializeDocument()
         )
+
+    def test_timed_log_attribute_is_added(self):
+        # If an item contains a TEI/XML transcript, it should have a usage attribute with value "timed_log"
+        if MediaFile(
+            item=self.audio_item,
+            file_type=MediaFileType.objects.get(file_code="text_master_transcript"),
+        ):
+            ohmods = self.get_mods_from_audio_item()
+            self.assertTrue(
+                b'<mods:url usage="timed log">' in ohmods.serializeDocument()
+            )
 
     def test_writing_single_mods(self):
         ohmods = self.get_mods_from_interview_item()


### PR DESCRIPTION
The public site expects TEI transcripts to have a `mods:location/mods:url[@usage="timed log"` attribute present in order to trigger specific functionality. This was removed in the initial implementation -- this commit adds it back.

This attribute value is not part of the [MODS specification](https://www.loc.gov/standards/mods/userguide/attributes.html#usage) for the location element, so no validation against the schema is done, either in tests or the application.

A minor change was made to the `OralHistoryMods` class, along with an additional test which confirms if a TEI transcript (filetype of `text_master_transcript`) is present, a `<mods:url usage="timed log">` tag is also present.

To test:
- Run tests, all should pass
- Generating an OAI record of an item that contains a TEI xml media file will output a `usage="timed log"` attribute/value. An example record can be found [here](http://localhost:8000/oai/?verb=GetRecord&identifier=21198/zz0008zmvt)