### PR TITLE
SYS-1577: Add internal host for improved OAI harvesting

### DIFF
--- a/charts/prod-ohstaff-values.yaml
+++ b/charts/prod-ohstaff-values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: uclalibrary/oral-history-staff-ui
-  tag: v1.0.8
+  tag: v1.0.9
   pullPolicy: Always
 
 nameOverride: ""
@@ -40,8 +40,10 @@ django:
     debug: "false"
     # DEBUG, INFO, WARNING, ERROR, CRITICAL
     log_level: "INFO"
+    # Public and private host names (for internal OAI harvesting)
     allowed_hosts:
       - oh-staff.library.ucla.edu
+      - oral-history-staff-ui-oh-staff.oh-staffprod.svc.cluster.local
     csrf_trusted_origins:
       - https://oh-staff.library.ucla.edu
     ark_minter: "http://noid.library.ucla.edu/noidu_zz8+?mint+1"

--- a/oh_staff_ui/templates/oh_staff_ui/release_notes.html
+++ b/oh_staff_ui/templates/oh_staff_ui/release_notes.html
@@ -4,6 +4,12 @@
 <h3>Release Notes</h3>
 <hr/>
 
+<h4>1.0.9</h4>
+<p><i>April 3, 2024</i></p>
+<ul>
+    <li>Added internal host to ALLOWED_HOSTS for improved OAI harvesting.</li>
+</ul>
+
 <h4>1.0.8</h4>
 <p><i>March 15, 2024</i></p>
 <ul>
@@ -16,6 +22,7 @@
 <p><i>March 14, 2024</i></p>
 <ul>
     <li>Added "timed log" attribute to OAI MODS records for TEI XML transcripts.</li>
+</ul>
 
 <h4>1.0.6</h4>
 <p><i>February 15, 2024</i></p>


### PR DESCRIPTION
Implements [SYS-1577](https://uclalibrary.atlassian.net/browse/SYS-1577).  Bumps version tag to `v1.0.9` for deployment.

This PR adds an internal host to Django's `ALLOWED_HOSTS` list, which will allow for more efficient networking between this staff application and the public application within our Kubernetes environment.

The new host was not added to `CSRF_TRUSTED_ORIGINS` as it will be used only for OAI-related `GET` requests, which should not be relevant for CSRF protection.


[SYS-1577]: https://uclalibrary.atlassian.net/browse/SYS-1577?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ