### PR TITLE
Adjust allowed_hosts value to be a comma-separated string

### DIFF
--- a/charts/Chart.yaml
+++ b/charts/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: "0.1"
 description: Chart for Oral History Staff UI
 name: oh-staff
-version: 0.2.0
+version: 0.3.0

--- a/charts/prod-ohstaff-values.yaml
+++ b/charts/prod-ohstaff-values.yaml
@@ -40,10 +40,8 @@ django:
     debug: "false"
     # DEBUG, INFO, WARNING, ERROR, CRITICAL
     log_level: "INFO"
-    # Public and private host names (for internal OAI harvesting)
-    allowed_hosts:
-      - oh-staff.library.ucla.edu
-      - oral-history-staff-ui-oh-staff.oh-staffprod.svc.cluster.local
+    # Comma-separated list of Public and private host names (for internal OAI harvesting)
+    allowed_hosts: oh-staff.library.ucla.edu,oral-history-staff-ui-oh-staff.oh-staffprod.svc.cluster.local
     csrf_trusted_origins:
       - https://oh-staff.library.ucla.edu
     ark_minter: "http://noid.library.ucla.edu/noidu_zz8+?mint+1"

--- a/charts/templates/configmap.yaml
+++ b/charts/templates/configmap.yaml
@@ -9,7 +9,7 @@ data:
   DJANGO_RUN_ENV: {{ .Values.django.env.run_env }}
   DJANGO_DEBUG: {{ .Values.django.env.debug | quote }}
   DJANGO_LOG_LEVEL: {{ .Values.django.env.log_level }}
-  DJANGO_ALLOWED_HOSTS: {{ range .Values.django.env.allowed_hosts }}{{ . | quote }}{{ end }}
+  DJANGO_ALLOWED_HOSTS: {{ .Values.django.env.allowed_hosts | quote }}
   DJANGO_CSRF_TRUSTED_ORIGINS: {{ range .Values.django.env.csrf_trusted_origins }}{{ . | quote }}{{ end }}
   DJANGO_ARK_MINTER: {{ .Values.django.env.ark_minter }}
   DJANGO_DB_BACKEND: {{ .Values.django.env.db_backend }}

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -33,10 +33,8 @@ django:
     run_env: "prod"
     debug: "false"
     log_level: ""
-    allowed_hosts: []
-    #  - localhost
-    #  - 127.0.0.1
-    #  - [::1]
+    # Comma-separated list of hostnames for allowed_hosts
+    allowed_hosts: ""
     csrf_trusted_origins: []
     ark_minter: ""
     db_backend: ""


### PR DESCRIPTION
We are provided a list of host names to the `allowed_hosts` value and it appears the way we were passing these to the configmap template using the `range` loop was not working correctly. 

Since Django is expecting a comma-separated list in projects.yaml, we'll just provide that in the values file. 