### PR TITLE
Ignore helm charts directory when determining when to run docker build gh action

### DIFF
--- a/.github/workflows/build_docker_hub.yml
+++ b/.github/workflows/build_docker_hub.yml
@@ -1,6 +1,8 @@
 name: Build for Docker Hub Oral History Staff UI
 on: 
   push:
+    paths-ignore:
+      - 'charts/**'
     branches:
       - main
   workflow_dispatch:


### PR DESCRIPTION
No need to run the docker build/push github action when we are only making changes within the helm charts directory. 