### PR TITLE
SYS-1594 Adjustment to mount the OH masters volume

### DIFF
--- a/charts/Chart.yaml
+++ b/charts/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: "0.1"
 description: Chart for Oral History Staff UI
 name: oh-staff
-version: 0.5.0
+version: 0.6.0

--- a/charts/prod-ohstaff-values.yaml
+++ b/charts/prod-ohstaff-values.yaml
@@ -56,6 +56,7 @@ django:
     # Where Django looks for uploaded files
     oh_media_root: "/media"
     # Relative paths within oh_media_root, used by Django
+    oh_masters: "oh_masters"
     oh_masterslz: "oh_lz"
     oh_static: "oh_static"
     oh_wowza: "oh_wowza"
@@ -78,6 +79,11 @@ persistentVolumes:
     server: "lib-partners.in.library.ucla.edu"
     path: "/OralHistory"
   ohmasters:
+    storage: "7Ti"
+    access: "ReadWriteMany"
+    server: "dlp.in.library.ucla.edu"
+    path: "/masters/nfs_mount/oralhistory"
+  ohmasterslz:
     storage: "1.1Ti"
     access: "ReadWriteMany"
     server: "dlp.in.library.ucla.edu"
@@ -104,6 +110,8 @@ volumeMounts:
   - name: "ohsource"
     mountPath: "/media/oh_source"
   - name: "ohmasters"
+    mountPath: "/media/oh_masters"
+  - name: "ohmasterslz"
     mountPath: "/media/oh_lz"
   - name: "ohwowza"
     mountPath: "/media/oh_wowza"

--- a/charts/templates/_helpers.tpl
+++ b/charts/templates/_helpers.tpl
@@ -60,6 +60,9 @@ Deployment Volume Configuration
 - name: "ohmasters"
   persistentVolumeClaim:
     claimName: {{ include "oh-staff.fullname" . }}-pvc-ohmasters
+- name: "ohmasterslz"
+  persistentVolumeClaim:
+    claimName: {{ include "oh-staff.fullname" . }}-pvc-ohmasterslz
 - name: "ohwowza"
   persistentVolumeClaim:
     claimName: {{ include "oh-staff.fullname" . }}-pvc-ohwowza

--- a/charts/templates/configmap.yaml
+++ b/charts/templates/configmap.yaml
@@ -19,6 +19,7 @@ data:
   DJANGO_DB_USER: {{ .Values.django.env.db_user }}
   DJANGO_OH_FILE_SOURCE: {{ .Values.django.env.oh_file_source }}
   DJANGO_OH_MEDIA_ROOT: {{ .Values.django.env.oh_media_root }}
+  DJANGO_OH_MASTERS: {{ .Values.django.env.oh_masters }}
   DJANGO_OH_MASTERSLZ: {{ .Values.django.env.oh_masterslz }}
   DJANGO_OH_STATIC: {{ .Values.django.env.oh_static }}
   DJANGO_OH_WOWZA: {{ .Values.django.env.oh_wowza }}

--- a/charts/templates/pv-ohmasterslz.yaml
+++ b/charts/templates/pv-ohmasterslz.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: {{ include "oh-staff.fullname" . }}-pv-ohmasterslz
+  {{- with .Values.persistentVolumesAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  capacity:
+    storage: {{ .Values.persistentVolumes.ohmasterslz.storage | quote }}
+  accessModes:
+    - {{ .Values.persistentVolumes.ohmasterslz.access }}
+  nfs:
+    server: {{ .Values.persistentVolumes.ohmasterslz.server | quote }}
+    path: {{ .Values.persistentVolumes.ohmasterslz.path | quote }}
+  mountOptions:
+    - nfsvers=3

--- a/charts/templates/pvc-ohmasterslz.yaml
+++ b/charts/templates/pvc-ohmasterslz.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "oh-staff.fullname" . }}-pvc-ohmasterslz
+  namespace: oh-staff{{ .Values.django.env.run_env }}
+  {{- with .Values.persistentVolumeClaimsAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  accessModes:
+    - {{ .Values.persistentVolumes.ohmasterslz.access }}
+  storageClassName: ""
+  resources:
+    requests:
+      storage: {{ .Values.persistentVolumes.ohmasterslz.storage }}
+  volumeName: {{ include "oh-staff.fullname" . }}-pv-ohmasterslz

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -47,6 +47,7 @@ django:
     oh_file_source: ""
     target_port: ""
     oh_media_root: ""
+    oh_masters: ""
     oh_masterslz: ""
     oh_static: ""
     oh_wowza: ""
@@ -70,6 +71,11 @@ persistentVolumes:
     server: ""
     path: ""
   ohmasters:
+    storage: ""
+    access: ""
+    server: ""
+    path: ""
+  ohmasterslz:
     storage: ""
     access: ""
     server: ""


### PR DESCRIPTION
The changes here allow for mounting both the original OH Master Landing Zone volume and the new OH Masters volume. 

Once we confirm using the new OH Masters volume is working as-expected, we can remove the Landing Zone volume. 

@akohler Please review these changes when you get a chance, in particular the changes I made in `prod-ohstaff-values.yaml` and the `configmap.yaml`. 