### PR TITLE
Updated TEI and image OAI feed to match public site display assumptions

### DIFF
--- a/charts/prod-ohstaff-values.yaml
+++ b/charts/prod-ohstaff-values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: uclalibrary/oral-history-staff-ui
-  tag: v1.0.11
+  tag: v1.0.12
   pullPolicy: Always
 
 nameOverride: ""

--- a/oh_staff_ui/classes/OralHistoryMods.py
+++ b/oh_staff_ui/classes/OralHistoryMods.py
@@ -177,12 +177,12 @@ class OralHistoryMods(MODSv34):
             ri.toc = TableOfContents(text=toc.value)
 
         for ts in MediaFile.objects.filter(
-            item=pi, file_type__file_code="text_master_index"
+            item=pi, file_type__file_code="text_master_transcript"
         ):
-            if ts.file_url != "":
-                ri.locations.append(
-                    LocationOH(url=ts.file_url, usage="primary display")
-                )
+            if ts.file_url != "" and ts.file_url.endswith(".xml"):
+                # Due to legacy design the text_master_transcript can have 2 file types
+                # associated with it, we only want to show xml (TEI), and ignore html files
+                ri.locations.append(LocationOH(url=ts.file_url, usage="timed log"))
 
         return ri
 
@@ -191,7 +191,7 @@ class OralHistoryMods(MODSv34):
             item=self._item, file_type__file_code="image_submaster"
         ).order_by("sequence"):
             self.locations.append(
-                LocationOH(url=img.file_url, label="Image of Narrator")
+                LocationOH(url=img.file_url, label="Image of Interviewee")
             )
 
     def _populate_interview_content(self):

--- a/oh_staff_ui/classes/OralHistoryMods.py
+++ b/oh_staff_ui/classes/OralHistoryMods.py
@@ -41,7 +41,7 @@ class OralHistoryMods(MODSv34):
         self._populate_rights()
         self._populate_subjects()
         self._populate_constituent_audio()
-        self._populate_narrator_image()
+        self._populate_interviewee_image()
         self._populate_interview_content()
         self._populate_series_content()
 
@@ -186,7 +186,7 @@ class OralHistoryMods(MODSv34):
 
         return ri
 
-    def _populate_narrator_image(self):
+    def _populate_interviewee_image(self):
         for img in MediaFile.objects.filter(
             item=self._item, file_type__file_code="image_submaster"
         ).order_by("sequence"):

--- a/oh_staff_ui/templates/oh_staff_ui/release_notes.html
+++ b/oh_staff_ui/templates/oh_staff_ui/release_notes.html
@@ -4,6 +4,13 @@
 <h3>Release Notes</h3>
 <hr/>
 
+<h4>1.0.12</h4>
+<p><i>April 26, 2024</i></p>
+<ul>
+    <li>Display value associated with images changed from Narrator to Interviewee in OAI feed</li>
+    <li>TEI documents are now presented as mods:location/mods:url[@="timed_log"] inside mods:relatedItem</li>
+</ul>
+
 <h4>1.0.11</h4>
 <p><i>April 26, 2024</i></p>
 <ul>

--- a/oh_staff_ui/tests.py
+++ b/oh_staff_ui/tests.py
@@ -1322,7 +1322,7 @@ class ModsTestCase(TestCase):
     def test_valid_mods_image(self):
         ohmods = self.get_mods_from_interview_item()
         self.assertTrue(
-            b'<mods:location displayLabel="Image of Narrator">'
+            b'<mods:location displayLabel="Image of Interviewee">'
             in ohmods.serializeDocument()
         )
 

--- a/oh_staff_ui/tests.py
+++ b/oh_staff_ui/tests.py
@@ -1,4 +1,3 @@
-from copy import deepcopy
 from lxml import etree
 from pathlib import Path
 from django.conf import settings
@@ -1363,7 +1362,8 @@ class ModsTestCase(TestCase):
         )
 
     def test_timed_log_attribute_is_added(self):
-        # If an item contains a TEI/XML transcript, it should have a usage attribute with value "timed_log"
+        # If an item contains a TEI/XML transcript, it should have a usage attribute
+        # with value "timed_log"
         if MediaFile(
             item=self.audio_item,
             file_type=MediaFileType.objects.get(file_code="text_master_transcript"),
@@ -1374,7 +1374,8 @@ class ModsTestCase(TestCase):
             )
 
     def test_absence_of_timed_log_with_text_master_index(self):
-        # If an item does not contain a file_code of text_master_transcript, mods:url[@usage="timed log"] should not be present
+        # If an item does not contain a file_code of text_master_transcript,
+        # mods:url[@usage="timed log"] should not be present.
 
         # Delete MediaFile associated with "text_master_transcript" file_code
         media_file = MediaFile.objects.get(


### PR DESCRIPTION
This PR addresses: 
- [SYS-1574](https://uclalibrary.atlassian.net/browse/SYS-1574) Image shows up in download options
- [SYS-1575](https://uclalibrary.atlassian.net/browse/SYS-1575) XML transcript does not appear in individual item display

Once the reason was hunted down the code changes were minimal. The label was changed for the interviewee image, which was triggering the download. The new label no longer includes `Narrator` which triggers the download.

The TEI xml transcript label was updated from `display label` to `timed log`, and an extra check was added to only include xml documents.

To test:
- Run tests via `docker compose exec django python manage.py test`, all should pass. Tests previously existed for transcripts and image, but the label check was corrected
- View [an item](http://localhost:8000/oai/?verb=GetRecord&identifier=21198/zz002kppdz) with an image. The following text should be present:
`<mods:location displayLabel="Image of Interviewee">
<mods:url>https://static.library.ucla.edu/oralhistory/submasters/21198-zz002kppdz-2-submaster.jpg</mods:url>
</mods:location>`
- View [an item](http://localhost:8000/oai/?verb=GetRecord&identifier=21198/zz00096c5n) with TEI transcripts (the timed log). The following text should be present:
```
<mods:relatedItem xlink:href="https://wowza.library.ucla.edu/dlp/definst/mp3:oralhistory/21198-zz0009d33f-1-submaster.mp3/playlist.m3u8" type="constituent">

<mods:titleInfo>

<mods:title>SESSION 1 (3/10/2008)</mods:title>

</mods:titleInfo>

<mods:identifier>21198/zz0009d33f</mods:identifier>

<mods:part order="1" type="session_audio"/>
...

<mods:location>
<mods:url usage="timed log">https://static.library.ucla.edu/oralhistory/text/submasters/21198-zz0009d33f-2-submaster.xml</mods:url>
</mods:location>


</mods:relatedItem>
```

[SYS-1574]: https://uclalibrary.atlassian.net/browse/SYS-1574?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SYS-1575]: https://uclalibrary.atlassian.net/browse/SYS-1575?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ