### PR TITLE
SYS-1531: Make square thumbnails

### DIFF
--- a/charts/prod-ohstaff-values.yaml
+++ b/charts/prod-ohstaff-values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: uclalibrary/oral-history-staff-ui
-  tag: v1.0.10
+  tag: v1.0.11
   pullPolicy: Always
 
 nameOverride: ""

--- a/oh_staff_ui/classes/ImageFileHandler.py
+++ b/oh_staff_ui/classes/ImageFileHandler.py
@@ -95,6 +95,8 @@ class ImageFileHandler(BaseFileHandler):
             with Image.open(input_name) as master_image:
                 new_sizes = self._get_new_image_dimensions(master_image.size, max_size)
                 derivative_image = master_image.resize(new_sizes)
+                if derivative_type == "thumbnail":
+                    derivative_image = self._make_square_thumbnail(derivative_image)
                 # Ordinary jpg does not support transparency, so convert if needed.
                 if derivative_image.mode in ("RGBA", "P"):
                     derivative_image = derivative_image.convert("RGB")
@@ -127,3 +129,17 @@ class ImageFileHandler(BaseFileHandler):
         scale_factor = max(current_sizes) / max_size
         new_sizes = tuple(int(dimension / scale_factor) for dimension in current_sizes)
         return new_sizes
+
+    def _make_square_thumbnail(self, thumbnail_image: Image.Image) -> Image.Image:
+        """Create a square thumbnail from a rectangular image, with black padding.
+        To be used after image is resized to thumbnail size.
+
+        Arguments:
+        thumbnail_image: image resized such that the longest side is the thumbnail size.
+        Returns: the square thumbnail.
+        """
+        x, y = thumbnail_image.size
+        size = max(x, y)
+        square_thumbnail = Image.new("RGB", (size, size), color="black")
+        square_thumbnail.paste(thumbnail_image, (int((size - x) / 2), int((size - y) / 2)))
+        return square_thumbnail

--- a/oh_staff_ui/classes/ImageFileHandler.py
+++ b/oh_staff_ui/classes/ImageFileHandler.py
@@ -138,8 +138,8 @@ class ImageFileHandler(BaseFileHandler):
         thumbnail_image: image resized such that the longest side is the thumbnail size.
         Returns: the square thumbnail.
         """
-        x, y = thumbnail_image.size
-        size = max(x, y)
+        width, height = thumbnail_image.size
+        size = max(width, height)
         square_thumbnail = Image.new("RGB", (size, size), color="black")
-        square_thumbnail.paste(thumbnail_image, (int((size - x) / 2), int((size - y) / 2)))
+        square_thumbnail.paste(thumbnail_image, (int((size - width) / 2), int((size - height) / 2)))
         return square_thumbnail

--- a/oh_staff_ui/templates/oh_staff_ui/release_notes.html
+++ b/oh_staff_ui/templates/oh_staff_ui/release_notes.html
@@ -4,6 +4,12 @@
 <h3>Release Notes</h3>
 <hr/>
 
+<h4>1.0.11</h4>
+<p><i>April 30, 2024</i></p>
+<ul>
+   <li>Made newly-generated thumbnail images always square, with black bars as needed.</li>
+</ul>
+
 <h4>1.0.10</h4>
 <p><i>April 5, 2024</i></p>
 <ul>

--- a/oh_staff_ui/tests.py
+++ b/oh_staff_ui/tests.py
@@ -1,5 +1,6 @@
 from lxml import etree
 from pathlib import Path
+from PIL import Image
 from django.conf import settings
 from django.core.files import File
 from django.core.management.base import CommandError
@@ -265,6 +266,17 @@ class MediaFileTestCase(TestCase):
         self.assertEqual(new_path.exists(), True)
         # Confirm master is parent of submaster.
         self.assertEqual(master.media_file, submaster.parent)
+
+    def test_thumbnail_image_size(self):
+        master = self.create_master_image_file()
+        handler = ImageFileHandler(master)
+        handler.process_files()
+        file_type = MediaFileType.objects.get(file_code="image_thumbnail")
+        thumbnail = MediaFile.objects.get(parent=master.media_file, file_type=file_type)
+        # Confirm that the thumbnail is square, and is of the size specified in settings.
+        thumbnail_size = settings.IMAGE_SETTINGS["thumbnail_long_dimension"]
+        with Image.open(self.get_full_path(thumbnail.file.name)) as img:
+            self.assertEqual(img.size, (thumbnail_size, thumbnail_size))
 
     def test_master_general_file_is_added(self):
         master = self.create_master_general_file()


### PR DESCRIPTION
Implements [SYS-1531](https://uclalibrary.atlassian.net/browse/SYS-1531)

Currently, the OH staff application creates both submaster and thumbnail derivative images in the same way: resize the image such that the longest dimension is the maximum size for the derivative type (750 px for submasters, 200 px for thumbnails), maintaining the aspect ratio. 

This PR changes the way that thumbnails are generated. Now, thumbnails are always 200x200 squares, with black bars vertically or horizontally bordering the resized image to fill any extra space. Example images are included on the [Jira ticket](https://uclalibrary.atlassian.net/browse/SYS-1531).

This is a small code change done entirely within the `ImageFileHandler` class. An additional test image (public domain, from Wikimedia Commons) is included to demonstrate the case that a master image is taller than it is wide. The other case (wider image) is demonstrated by the existing `sample_marbles.tif` file.

[SYS-1531]: https://uclalibrary.atlassian.net/browse/SYS-1531?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ