### PR TITLE
SYS-1601: add reprocess_derivative_images command

### DIFF
--- a/charts/prod-ohstaff-values.yaml
+++ b/charts/prod-ohstaff-values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: uclalibrary/oral-history-staff-ui
-  tag: v1.1.1
+  tag: v1.1.2
 
   pullPolicy: Always
 

--- a/charts/prod-ohstaff-values.yaml
+++ b/charts/prod-ohstaff-values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: uclalibrary/oral-history-staff-ui
-  tag: v1.0.14
+  tag: v1.0.15
   pullPolicy: Always
 
 nameOverride: ""

--- a/charts/prod-ohstaff-values.yaml
+++ b/charts/prod-ohstaff-values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: uclalibrary/oral-history-staff-ui
-  tag: v1.0.15
+  tag: v1.1.1
   pullPolicy: Always
 
 nameOverride: ""

--- a/oh_staff_ui/management/commands/reprocess_derivative_images.py
+++ b/oh_staff_ui/management/commands/reprocess_derivative_images.py
@@ -1,0 +1,115 @@
+import logging
+from pathlib import Path
+from django.core.management.base import BaseCommand, CommandParser
+from django.core.management.base import CommandError
+from django.http import HttpRequest
+from django.db.models.query import QuerySet
+from django.conf import settings
+from oh_staff_ui.classes.ImageFileHandler import ImageFileHandler
+from oh_staff_ui.classes.OralHistoryFile import OralHistoryFile
+from oh_staff_ui.models import MediaFile, MediaFileType
+
+# For handling command-line processing
+from django.contrib.auth.models import User
+
+
+logger = logging.getLogger(__name__)
+
+
+def reprocess_derivative_images(master_images: QuerySet) -> None:
+    """Reprocess all derivative images from masters."""
+    try:
+        for master_image in master_images:
+            logger.info(f"Processing master image {master_image.file.name}")
+            # Get id of newly created MediaFile to use as parent for derivative(s)
+            master_id = master_image.id
+            # Create an OHF for the master file so we can use ImageFileHandler
+            master_file = OralHistoryFile(
+                master_image.item.id,
+                Path(settings.MEDIA_ROOT).joinpath(master_image.file.name),
+                master_image.file_type,
+                "master",
+                get_mock_request(),
+            )
+            handler = ImageFileHandler(master_file)
+
+            # Submaster - generate and save
+            submaster_file_name = handler.create_submaster()
+            submaster_file = OralHistoryFile(
+                item_id=master_image.item.id,
+                file_name=submaster_file_name,
+                file_type=MediaFileType.objects.get(file_code="image_submaster"),
+                file_use="submaster",
+                request=get_mock_request(),
+            )
+            submaster_file.process_media_file(parent_id=master_id)
+            logger.info(f"Submaster image {submaster_file_name} created")
+
+            # Thumbnail - generate and save
+            thumbnail_file_name = handler.create_thumbnail()
+            thumbnail_file = OralHistoryFile(
+                item_id=master_image.item.id,
+                file_name=thumbnail_file_name,
+                file_type=MediaFileType.objects.get(file_code="image_thumbnail"),
+                file_use="thumbnail",
+                request=get_mock_request(),
+            )
+            thumbnail_file.process_media_file(parent_id=master_id)
+            logger.info(f"Thumbnail image {thumbnail_file_name} created")
+
+    except (CommandError, ValueError) as ex:
+        logger.error(ex)
+        raise
+
+
+def delete_existing_derivative_images(master_images: QuerySet) -> None:
+    """Delete existing derivative images from masters."""
+    try:
+        for master_image in master_images:
+            master_id = master_image.id
+            MediaFile.objects.filter(
+                item=master_image.item,
+                parent_id=master_id,
+                file_type__file_code__in=["image_submaster", "image_thumbnail"],
+            ).delete()
+            logger.info(
+                f"Deleted existing derivative images for master {master_image.file.name}"
+            )
+
+    except (CommandError, ValueError) as ex:
+        logger.error(ex)
+        raise
+
+
+def get_mock_request() -> HttpRequest:
+    """Get mock request with generic user info for command-line processing."""
+    mock_request = HttpRequest()
+    mock_request.user = User.objects.get(username="oralhistory")
+    return mock_request
+
+
+class Command(BaseCommand):
+    help = "Django management command to reprocess derivative images"
+
+    def add_arguments(self, parser: CommandParser) -> None:
+        parser.add_argument(
+            "--project_item_id",
+            type=int,
+            help="ID of ProjectItem to reprocess derivative images for",
+            required=False,
+        )
+
+    def handle(self, *args, **options) -> None:
+        if options["project_item_id"]:
+            master_images = MediaFile.objects.filter(
+                item__id=options["project_item_id"],
+                file_type__file_code="image_master",
+            ).order_by("id")
+
+        else:
+            master_images = MediaFile.objects.filter(
+                file_type__file_code="image_master"
+            ).order_by("id")
+
+        delete_existing_derivative_images(master_images)
+        reprocess_derivative_images(master_images)

--- a/oh_staff_ui/management/commands/reprocess_derivative_images.py
+++ b/oh_staff_ui/management/commands/reprocess_derivative_images.py
@@ -111,5 +111,8 @@ class Command(BaseCommand):
                 file_type__file_code="image_master"
             ).order_by("id")
 
+        master_image_count = master_images.count()
+        logger.info(f"Found {master_image_count} master images to reprocess")
+
         delete_existing_derivative_images(master_images)
         reprocess_derivative_images(master_images)

--- a/oh_staff_ui/management/commands/reprocess_derivative_images.py
+++ b/oh_staff_ui/management/commands/reprocess_derivative_images.py
@@ -82,7 +82,8 @@ def delete_existing_derivative_images(master_images: QuerySet) -> None:
         for master_image in master_images:
             project_item = master_image.item
             logger.info(
-                f"Deleting existing derivative images for project item {project_item}."
+                f"Deleting existing derivative images for project item {project_item} "
+                f"(ID {project_item.id})."
             )
             files_to_delete = MediaFile.objects.filter(
                 item=project_item,
@@ -116,7 +117,8 @@ def delete_existing_derivative_images(master_images: QuerySet) -> None:
                     logger.info(f"Deleted MediaFile {mediafile_id} from database.")
 
             logger.info(
-                f"Finished deleting existing derivative images for project item {project_item}."
+                f"Finished deleting existing derivative images for project item {project_item} "
+                f"(ID {project_item.id})."
             )
 
     except (CommandError, ValueError) as ex:

--- a/oh_staff_ui/templates/oh_staff_ui/release_notes.html
+++ b/oh_staff_ui/templates/oh_staff_ui/release_notes.html
@@ -4,6 +4,12 @@
 <h3>Release Notes</h3>
 <hr/>
 
+<h4>1.0.15</h4>
+<p><i>May 2, 2024</i></p>
+<ul>
+    <li>Added command to reprocess all derivative images.</li>
+</ul>
+
 <h4>1.0.14</h4>
 <p><i>May 1, 2024</i></p>
 <ul>

--- a/oh_staff_ui/templates/oh_staff_ui/release_notes.html
+++ b/oh_staff_ui/templates/oh_staff_ui/release_notes.html
@@ -4,10 +4,16 @@
 <h3>Release Notes</h3>
 <hr/>
 
-<h4>1.1.1</h4>
+<h4>1.1.2</h4>
 <p><i>May 8, 2024</i></p>
 <ul>
    <li>Added command to reprocess all derivative images.</li>
+</ul>
+
+<h4>1.1.1</h4>
+<p><i>May 8, 2024</i></p>
+<ul>
+   <li>Enabled access to master files, really this time.</li>
 </ul>
 
 <h4>1.1.0</h4>

--- a/oh_staff_ui/templates/oh_staff_ui/release_notes.html
+++ b/oh_staff_ui/templates/oh_staff_ui/release_notes.html
@@ -4,10 +4,16 @@
 <h3>Release Notes</h3>
 <hr/>
 
-<h4>1.0.15</h4>
-<p><i>May 2, 2024</i></p>
+<h4>1.1.1</h4>
+<p><i>May 8, 2024</i></p>
 <ul>
-    <li>Added command to reprocess all derivative images.</li>
+   <li>Added command to reprocess all derivative images.</li>
+</ul>
+
+<h4>1.1.0</h4>
+<p><i>May 7, 2024</i></p>
+<ul>
+   <li>Enabled access to master files.</li>
 </ul>
 
 <h4>1.0.14</h4>

--- a/oh_staff_ui/tests.py
+++ b/oh_staff_ui/tests.py
@@ -1557,12 +1557,11 @@ class FileMetadataMigrationTestCase(SimpleTestCase):
         self.assertEqual(full_file_name, "oh_wowza/21198-zz00094qtd-3-submaster.mp3")
 
 
-class reprocessDerivativeImagesTestCase(TestCase):
+class ReprocessDerivativeImagesTestCase(TestCase):
     # Load the lookup tables needed for these tests.
     fixtures = [
         "item-status-data.json",
         "item-type-data.json",
-        "authority-source-data.json",
         "media-file-type-data.json",
     ]
 
@@ -1690,15 +1689,11 @@ class reprocessDerivativeImagesTestCase(TestCase):
 
     def tearDown(self) -> None:
         # remove the files created by the test
-        thumbnail_path = Path(
-            f"{settings.MEDIA_ROOT}/oh_static/nails/fake-abcdef-1-thumbnail.jpg"
-        )
-        submaster_path = Path(
-            f"{settings.MEDIA_ROOT}/oh_static/submasters/fake-abcdef-1-submaster.jpg"
-        )
-        thumbnail_path.unlink(missing_ok=True)
-        submaster_path.unlink(missing_ok=True)
+        thumbnail_path = Path(f"{settings.MEDIA_ROOT}/oh_static/nails/")
+        submaster_path = Path(f"{settings.MEDIA_ROOT}/oh_static/submasters/")
+        master_path = Path(f"{settings.MEDIA_ROOT}/oh_masters/masters/")
+        rmtree(thumbnail_path)
+        rmtree(submaster_path)
+        rmtree(master_path)
         # remove MediaFile objects created by the test
         MediaFile.objects.filter(item=self.item).delete()
-
-        return super().tearDown()

--- a/oh_staff_ui/tests.py
+++ b/oh_staff_ui/tests.py
@@ -1701,12 +1701,11 @@ class ReprocessDerivativeImagesTestCase(TestCase):
         self.assertTrue(submaster_path.is_file())
 
     def tearDown(self) -> None:
-        # remove the files created by the test
-        thumbnail_path = Path(f"{settings.MEDIA_ROOT}/oh_static/nails/")
-        submaster_path = Path(f"{settings.MEDIA_ROOT}/oh_static/submasters/")
-        master_path = Path(f"{settings.MEDIA_ROOT}/oh_masters/masters/")
-        rmtree(thumbnail_path)
-        rmtree(submaster_path)
-        rmtree(master_path)
-        # remove MediaFile objects created by the test
-        MediaFile.objects.filter(item=self.item).delete()
+        media_files = MediaFile.objects.filter(item=self.item)
+        # delete files on disk first
+        for mf in media_files:
+            if mf.file:
+                mf.file.delete()
+        # delete MediaFile objects starting with the parent - CASCADE will delete children
+        for parent_mf in media_files.filter(parent__isnull=True):
+            parent_mf.delete()

--- a/oh_staff_ui/views.py
+++ b/oh_staff_ui/views.py
@@ -132,7 +132,7 @@ def show_log(request, line_count: int = 200) -> HttpResponse:
 @login_required
 def upload_file(request: HttpRequest, item_id: int) -> HttpResponse:
     item = ProjectItem.objects.get(pk=item_id)
-    files = MediaFile.objects.filter(item=item)
+    files = MediaFile.objects.filter(item=item).order_by("sequence")
     file_errors = MediaFileError.objects.filter(item=item).order_by("create_date")
     if request.method == "POST":
         # Pass item_id and request to submitted form to help with validation.

--- a/oh_staff_ui/views.py
+++ b/oh_staff_ui/views.py
@@ -132,7 +132,9 @@ def show_log(request, line_count: int = 200) -> HttpResponse:
 @login_required
 def upload_file(request: HttpRequest, item_id: int) -> HttpResponse:
     item = ProjectItem.objects.get(pk=item_id)
-    files = MediaFile.objects.filter(item=item).order_by("sequence")
+    files = MediaFile.objects.filter(item=item).order_by(
+        "sequence", "file_type__file_code"
+    )
     file_errors = MediaFileError.objects.filter(item=item).order_by("create_date")
     if request.method == "POST":
         # Pass item_id and request to submitted form to help with validation.


### PR DESCRIPTION
Implements [SYS-1601](https://uclalibrary.atlassian.net/browse/SYS-1601)

Adds a new Django management command, `reprocess_derivative_images`. This command takes one optional argument, `--project_item_id`. If supplied, only images associated with the specified ProjectItem will be reprocessed. Otherwise, all images will be processed. Example usage: ```docker-compose exec django python manage.py reprocess_derivative_images --project_item_id 10331```

This command simply creates new derivative images from all master images instead of attempting to determine which ones require correction. This is simpler, and has the advantage that the new derivative images are now correctly associated with their respective masters through the `parent` field. The "created by" metadata is altered for the derivatives, but remains intact for masters.

My testing was limited to files I uploaded myself, since the original files must actually exist in the expected media directory. Please check if the path to access original master files (line 29 of `reprocess_derivative_images.py`) will work in production - I'm a bit unsure of this.

Finally, this PR also includes:
* A tiny change to `views.py` to sort the file information on the file upload page by sequence number. The default sorting (chronological?) was inconvenient after reprocessing a ProjectItem with multiple masters.
* Release notes and tag bump for deployment.

[SYS-1601]: https://uclalibrary.atlassian.net/browse/SYS-1601?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ