### PR TITLE
SYS-934: Enable access to master files

### DIFF
--- a/.docker-compose_django.env
+++ b/.docker-compose_django.env
@@ -20,9 +20,9 @@ DJANGO_CSRF_TRUSTED_ORIGINS=https://oh-staff.library.ucla.edu
 # DEBUG, INFO, WARNING, ERROR, CRITICAL
 DJANGO_LOG_LEVEL=DEBUG
 
-# For createsuperuser
-DJANGO_SUPERUSER_USERNAME=admin
-DJANGO_SUPERUSER_PASSWORD=admin
+# For createsuperuser - local use only
+DJANGO_SUPERUSER_USERNAME=dev_admin
+DJANGO_SUPERUSER_PASSWORD=dev_admin
 DJANGO_SUPERUSER_EMAIL=softwaredev-systems@library.ucla.edu
 
 # URL to ARK minter (PROD)

--- a/.docker-compose_django.env
+++ b/.docker-compose_django.env
@@ -41,6 +41,16 @@ DJANGO_OH_MEDIA_ROOT=/tmp/media_dev
 DJANGO_OH_MASTERS=oh_masters
 # Wowza
 DJANGO_OH_WOWZA=oh_wowza
-# Static files
+# Static files (in the UCLA scope, not related to
+# Django's STATICFILES etc.)
 DJANGO_OH_STATIC=oh_static
+
+# URL prefix for non-audio submasters (mainly jpg/pdf/xml)
+# handled by UCLA's main static file server.
+DJANGO_OH_STATIC_URL_PREFIX="https://static.library.ucla.edu/oralhistory/"
+# URL prefix for audio submasters
+DJANGO_OH_WOWZA_URL_PREFIX="https://wowza.library.ucla.edu/dlp/definst/mp3:oralhistory/"
+
+# URL for linking to public interface.
 DJANGO_OH_PUBLIC_SITE=https://oralhistory.library.ucla.edu
+

--- a/README.md
+++ b/README.md
@@ -86,7 +86,9 @@ The container runs via `docker_scripts/entrypoint.sh`, which
    ```
 7. Connect to the running application via browser
 
-   [Application](http://127.0.0.1:8000) and [Admin](http://127.0.0.1:8000/admin)
+   * [Application](http://127.0.0.1:8000) and [Admin](http://127.0.0.1:8000/admin)
+     * Username: `dev_admin`
+     * Password: `dev_admin`
 
 8. Edit code locally.  All changes are immediately available in the running container, but if a restart is needed:
 

--- a/charts/Chart.yaml
+++ b/charts/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: "0.1"
 description: Chart for Oral History Staff UI
 name: oh-staff
-version: 0.7.0
+version: 0.8.0

--- a/charts/prod-ohstaff-values.yaml
+++ b/charts/prod-ohstaff-values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: uclalibrary/oral-history-staff-ui
-  tag: v1.0.14
+  tag: v1.1.0
   pullPolicy: Always
 
 nameOverride: ""
@@ -59,6 +59,12 @@ django:
     oh_masters: "oh_masters"
     oh_static: "oh_static"
     oh_wowza: "oh_wowza"
+    # URL prefix for non-audio submasters (mainly jpg/pdf/xml)
+    # handled by UCLA's main static file server.
+    oh_static_url_prefix: "https://static.library.ucla.edu/oralhistory/"
+    # URL prefix for audio submasters
+    oh_wowza_url_prefix: "https://wowza.library.ucla.edu/dlp/definst/mp3:oralhistory/"
+    # URL for linking to public interface.
     oh_public_site: "https://oralhistory.library.ucla.edu"
 
   externalSecrets:

--- a/charts/templates/configmap.yaml
+++ b/charts/templates/configmap.yaml
@@ -22,5 +22,6 @@ data:
   DJANGO_OH_MASTERS: {{ .Values.django.env.oh_masters }}
   DJANGO_OH_STATIC: {{ .Values.django.env.oh_static }}
   DJANGO_OH_WOWZA: {{ .Values.django.env.oh_wowza }}
+  DJANGO_OH_STATIC_URL_PREFIX: {{ .Values.django.env.oh_static_url_prefix }}
+  DJANGO_OH_WOWZA_URL_PREFIX: {{ .Values.django.env.oh_wowza_url_prefix }}
   DJANGO_OH_PUBLIC_SITE: {{ .Values.django.env.oh_public_site }}
-  

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -50,6 +50,8 @@ django:
     oh_masters: ""
     oh_static: ""
     oh_wowza: ""
+    oh_static_url_prefix: ""
+    oh_wowza_url_prefix: ""
     oh_public_site: ""
 
   externalSecrets:

--- a/oh_staff_ui/management/commands/process_file.py
+++ b/oh_staff_ui/management/commands/process_file.py
@@ -52,7 +52,7 @@ def process_file(
 def get_mock_request() -> HttpRequest:
     """Get mock request with generic user info for command-line processing."""
     mock_request = HttpRequest()
-    mock_request.user = User.objects.get(username="oralhistory")
+    mock_request.user = User.objects.get(username="oralhistory data entry")
     return mock_request
 
 

--- a/oh_staff_ui/templates/oh_staff_ui/release_notes.html
+++ b/oh_staff_ui/templates/oh_staff_ui/release_notes.html
@@ -4,6 +4,12 @@
 <h3>Release Notes</h3>
 <hr/>
 
+<h4>1.1.0</h4>
+<p><i>May 7, 2024</i></p>
+<ul>
+   <li>Enabled access to master files.</li>
+</ul>
+
 <h4>1.0.14</h4>
 <p><i>May 1, 2024</i></p>
 <ul>

--- a/oh_staff_ui/urls.py
+++ b/oh_staff_ui/urls.py
@@ -1,3 +1,5 @@
+from django.conf import settings
+from django.conf.urls.static import static
 from django.urls import path
 from . import views
 
@@ -23,3 +25,8 @@ urlpatterns = [
     path("oai/", views.oai, name="oai"),
     path("release_notes/", views.release_notes, name="release_notes"),
 ]
+
+# Enable serving media files.  In local dev environment, this is all files;
+# in production, this applies only to master files, which are rarely accessed
+# and can't practically be served in any other way.
+urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/project/settings.py
+++ b/project/settings.py
@@ -198,6 +198,10 @@ LOGIN_REDIRECT_URL = "/"
 # ARK minter
 ARK_MINTER = os.getenv("DJANGO_ARK_MINTER")
 
+# URL base for files served from MEDIA_ROOT;
+# this is the same in all environments.
+MEDIA_URL = "/media/"
+
 # Directories for uploaded files and their derivatives.
 MEDIA_ROOT = os.getenv("DJANGO_OH_MEDIA_ROOT")
 
@@ -208,9 +212,18 @@ OH_FILE_SOURCE = os.getenv("DJANGO_OH_FILE_SOURCE")
 OH_MASTERS = os.getenv("DJANGO_OH_MASTERS")
 # Wowza
 OH_WOWZA = os.getenv("DJANGO_OH_WOWZA")
-# Static files
+# Static files (in the UCLA scope, not related to
+# Django's STATICFILES etc.)
 OH_STATIC = os.getenv("DJANGO_OH_STATIC")
 
+# TODO: 20240503 add these URL_PREFIX variables to Helm chart.
+# URL prefix for non-audio submasters (mainly jpg/pdf/xml)
+# handled by UCLA's main static file server.
+OH_STATIC_URL_PREFIX = os.getenv("DJANGO_OH_STATIC_URL_PREFIX")
+# URL prefix for audio submasters
+OH_WOWZA_URL_PREFIX = os.getenv("DJANGO_OH_WOWZA_URL_PREFIX")
+
+# URL for linking to public interface.
 OH_PUBLIC_SITE = os.getenv("DJANGO_OH_PUBLIC_SITE")
 
 # Image conversion settings


### PR DESCRIPTION
Implements [SYS-934](https://uclalibrary.atlassian.net/browse/SYS-934).  Bumps version to `v1.1.0` for deployment; requires `gitops_kubernetes` update as well due to chart changes.

This PR adds the ability to access master files via the staff interface.  Caveat: this **should** work in the production environment... but I won't be sure until it's deployed.

Master files now have links on the `upload_file` page, which should allow direct viewing / download depending on browser settings.  These files are served via Django's [MEDIA_URL](https://docs.djangoproject.com/en/4.2/ref/settings/#std-setting-MEDIA_URL) setting, which allows Django to serve user-uploaded files.  Normally this should not be done in production, but the use case for Oral History staff (infrequent non-public need) is acceptable, I think.

The `MediaFile.file_url` property has changed so that in the `DEV` environment, all media files (masters and derivatives) are now served via `MEDIA_URL`.  This makes it easier to access locally-uploaded files in the Docker container during development.  In Production, only master files are accessible in this way; derivatives are still served via `static.library.ucla.edu` or Wowza, the same way they're accessed in the public site.

Other changes:
* URLs for accessing derivatives were refactored into environment variables.
* Relevant tests for `file_url` were updated to use the Production context, since that's what matters most.
* Local Django superuser changed from `admin` to `dev_admin` to remove conflict when importing production data dumps locally.
  * This user is now documented in `README.md`
* Generic user for mock requests in `process_file` command changed from `oralhistory` to `oralhistory data entry`, matching production username.
* Added `ModsTestCase.tearDownClass()` to remove `mods.xml` file created by tests.

### Testing

Restart `docker-compose` system to load new environment variables.

There are 99 test cases, all passing, via `docker-compose exec django python manage.py test`

For manual testing: add various media files to a test item.  I tested with audio, image, xml, and pdf.  There should be links on all files.  Depending on browser configuration, links may show files or cause downloads when left-clicked.  RIght-clicking any link should allow download via normal browser functionality.

Example of media file structure after adding audio, image, xml, and pdf to one local item.
```
# Install the tree utility into the container, for convenience
$ docker-compose exec -u root django bash -c "apt-get install tree"

# View tree of uploaded media files; fake ARK will vary
$ docker-compose exec django bash -c "tree /tmp/media_dev"
/tmp/media_dev
├── oh_masters
│   ├── audio
│   │   └── masters
│   │       └── fake-6bb10594bf-1-master.wav
│   ├── masters
│   │   └── fake-6bb10594bf-4-master.tif
│   ├── pdf
│   │   └── masters
│   │       └── fake-6bb10594bf-2-master.pdf
│   └── text
│       └── masters
│           └── fake-6bb10594bf-3-master.xml
├── oh_static
│   ├── nails
│   │   └── fake-6bb10594bf-4-thumbnail.jpg
│   ├── pdf
│   │   └── submasters
│   │       └── fake-6bb10594bf-2-submaster.pdf
│   ├── submasters
│   │   └── fake-6bb10594bf-4-submaster.jpg
│   └── text
│       └── submasters
│           └── fake-6bb10594bf-3-submaster.xml
└── oh_wowza
    └── audio
        └── submasters
            └── fake-6bb10594bf-1-submaster.mp3

18 directories, 9 files
```


[SYS-934]: https://uclalibrary.atlassian.net/browse/SYS-934?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ