### PR TITLE
SYS-934: Fix master file access in production

### DIFF
--- a/charts/prod-ohstaff-values.yaml
+++ b/charts/prod-ohstaff-values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: uclalibrary/oral-history-staff-ui
-  tag: v1.1.0
+  tag: v1.1.1
   pullPolicy: Always
 
 nameOverride: ""

--- a/oh_staff_ui/templates/oh_staff_ui/release_notes.html
+++ b/oh_staff_ui/templates/oh_staff_ui/release_notes.html
@@ -4,6 +4,12 @@
 <h3>Release Notes</h3>
 <hr/>
 
+<h4>1.1.1</h4>
+<p><i>May 8, 2024</i></p>
+<ul>
+   <li>Enabled access to master files, really this time.</li>
+</ul>
+
 <h4>1.1.0</h4>
 <p><i>May 7, 2024</i></p>
 <ul>

--- a/oh_staff_ui/urls.py
+++ b/oh_staff_ui/urls.py
@@ -1,6 +1,6 @@
 from django.conf import settings
-from django.conf.urls.static import static
-from django.urls import path
+from django.views.static import serve
+from django.urls import path, re_path
 from . import views
 
 urlpatterns = [
@@ -19,14 +19,11 @@ urlpatterns = [
     path("upload_file/<int:item_id>", views.upload_file, name="upload_file"),
     path("order_files/<int:item_id>", views.order_files, name="order_files"),
     path("browse/", views.browse, name="browse"),
+    # Allow access to download media files via built-in view django.views.static.serve()
+    re_path(r"^media/(?P<path>.*)$", serve, {"document_root": settings.MEDIA_ROOT}),
     # To follow OAI practice, a query parameter combination is requred of either:
     # verb=GetRecord and identifier={ark_value}
     # verb=ListRecords
     path("oai/", views.oai, name="oai"),
     path("release_notes/", views.release_notes, name="release_notes"),
 ]
-
-# Enable serving media files.  In local dev environment, this is all files;
-# in production, this applies only to master files, which are rarely accessed
-# and can't practically be served in any other way.
-urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)


### PR DESCRIPTION
Fixes a problem with [SYS-934](https://uclalibrary.atlassian.net/browse/SYS-934).  Bumps version to `v1.1.1` for deployment.

This PR should fix a problem caused by my misunderstanding of how media (user-uploaded) files are handled by Django in production environments, when `DEBUG=False`.  It uses Django's built-in view `django.views.static.serve()` to serve files in `MEDIA_ROOT`... which is similar to what I was doing before, via a different built-in view which I thought was a short-cut for this functionality.  Apparently serving via `MEDIA_URL` is not allowed in production, but serving files from the place `MEDIA_URL` points to... is.

Along with this minor change in `urls.py`, I added a test which forces simulation of production mode `(RUN_ENV="prod", DEBUG=False)` and uses Django's built-in test client to confirm that a request for a media file succeeds (response status code 200).

I also started my local environment with those two environment variables set as above:
```
    environment:
      # Force the environment to be production, when connecting from Docker in this way.
      - DJANGO_RUN_ENV=prod
      - DJANGO_DEBUG=False
```
Master files were accessible in this environment.

Finally, I started my local environment in the normal way, and master files (and all other local files) were available as expected.

So, I'm hopeful....


[SYS-934]: https://uclalibrary.atlassian.net/browse/SYS-934?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ