### PR TITLE
SYS-1598: allow deletion of derivative media files

### DIFF
--- a/charts/prod-ohstaff-values.yaml
+++ b/charts/prod-ohstaff-values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: uclalibrary/oral-history-staff-ui
-  tag: v1.1.5
+  tag: v1.1.5a
   pullPolicy: Always
 
 nameOverride: ""

--- a/charts/prod-ohstaff-values.yaml
+++ b/charts/prod-ohstaff-values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: uclalibrary/oral-history-staff-ui
-  tag: v1.1.5a
+  tag: v1.1.6
   pullPolicy: Always
 
 nameOverride: ""

--- a/oh_staff_ui/templates/oh_staff_ui/release_notes.html
+++ b/oh_staff_ui/templates/oh_staff_ui/release_notes.html
@@ -4,6 +4,12 @@
 <h3>Release Notes</h3>
 <hr/>
 
+<h4>1.1.6</h4>
+<p><i>May 22, 2024</i></p>
+<ul>
+   <li>Added ability to delete files from item records.</li>
+</ul>
+
 <h4>1.1.5</h4>
 <p><i>May 21, 2024</i></p>
 <ul>

--- a/oh_staff_ui/templates/oh_staff_ui/upload_file.html
+++ b/oh_staff_ui/templates/oh_staff_ui/upload_file.html
@@ -54,6 +54,14 @@
   <div class = "confirm-delete-popup" id="confirm-delete-popup-{{file.id}}">
     <h3>Delete file?</h3>
     <p>Are you sure you want to delete this file: {{file.file_name_only}}?</p>
+    {% if file.children %}
+    <p>This file has derivative files. Deleting this file will also delete the following files:</p>
+    <ul>
+      {% for child in file.children %}
+      <li>{{ child.file_name_only }}</li>
+      {% endfor %}
+    </ul>
+    {% endif %}
     <a href="#" class="btn btn-primary" id="cancel-{{file.id}}" onclick="hideConfirmDeletePopup('{{file.id}}')">No</a>
     <a href="{% url 'delete_file' file.id %}" class="btn btn-secondary">Yes</a> 
   </div>
@@ -72,9 +80,7 @@
     <td>{{ file.sequence }}</td>
     {% if staff_status %}  
     <td>
-      {% if file.parent != None %}
       <button class="delete-link btn btn-primary" onclick="showConfirmDeletePopup('{{ file.id }}')">Delete</button>
-      {% endif %}
     </td>
     {% endif %}
   </tr>

--- a/oh_staff_ui/templates/oh_staff_ui/upload_file.html
+++ b/oh_staff_ui/templates/oh_staff_ui/upload_file.html
@@ -62,8 +62,8 @@
       {% endfor %}
     </ul>
     {% endif %}
-    <a href="#" class="btn btn-primary" id="cancel-{{file.id}}" onclick="hideConfirmDeletePopup('{{file.id}}')">No</a>
-    <a href="{% url 'delete_file' file.id %}" class="btn btn-secondary">Yes</a> 
+    <a href="#" class="btn btn-primary" id="cancel-{{file.id}}" onclick="hideConfirmDeletePopup('{{file.id}}')">Cancel</a>
+    <a href="{% url 'delete_file' file.id %}" class="btn btn-secondary">Delete</a> 
   </div>
   <tr>
     <td>{{ file.file_type }}</td>

--- a/oh_staff_ui/templates/oh_staff_ui/upload_file.html
+++ b/oh_staff_ui/templates/oh_staff_ui/upload_file.html
@@ -35,7 +35,6 @@
       </td>
   </tr>
 </table>
-
 {% if files %}
 <hr>
 <table class="header-metadata caption-top">
@@ -47,8 +46,17 @@
     <th>New name & location</th>
     <th>Size</th>
     <th>Sequence</th>
+    {% if staff_status %}
+    <th>Actions</th>
+    {% endif %}
   </tr>
   {% for file in files %}
+  <div class = "confirm-delete-popup" id="confirm-delete-popup-{{file.id}}">
+    <h3>Delete file?</h3>
+    <p>Are you sure you want to delete this file: {{file.file_name_only}}?</p>
+    <a href="#" class="btn btn-primary" id="cancel-{{file.id}}" onclick="hideConfirmDeletePopup('{{file.id}}')">No</a>
+    <a href="{% url 'delete_file' file.id %}" class="btn btn-secondary">Yes</a> 
+  </div>
   <tr>
     <td>{{ file.file_type }}</td>
     <td>{{ file.create_date }} by {{ file.created_by }}</td>
@@ -62,6 +70,13 @@
     </td>
     <td>{{ file.file_size|floatformat:"g" }} bytes</td>
     <td>{{ file.sequence }}</td>
+    {% if staff_status %}  
+    <td>
+      {% if file.parent != None %}
+      <button class="delete-link btn btn-primary" onclick="showConfirmDeletePopup('{{ file.id }}')">Delete</button>
+      {% endif %}
+    </td>
+    {% endif %}
   </tr>
   {% endfor %}
 </table>
@@ -125,4 +140,5 @@
   </table>
     {% bootstrap_button button_type="submit" content="Upload" %}
 </form>
+
 {% endblock %}

--- a/oh_staff_ui/tests.py
+++ b/oh_staff_ui/tests.py
@@ -1778,7 +1778,7 @@ class FileDeletionTestCase(TestCase):
             item=self.item, file_type__file_code="image_master"
         )
         # delete Master and derivative files
-        delete_file_and_children(image_mediafile)
+        delete_file_and_children(image_mediafile, self.user)
 
         # check that all 3 MediaFiles are deleted
         self.assertFalse(MediaFile.objects.filter(item=self.item).exists())
@@ -1813,7 +1813,7 @@ class FileDeletionTestCase(TestCase):
             item=self.item, file_type__file_code="image_submaster"
         )
         # delete files
-        delete_file_and_children(submaster_mediafile)
+        delete_file_and_children(submaster_mediafile, self.user)
 
         # check that master and thumbnail files are still there (in DB and on disk)
         self.assertTrue(MediaFile.objects.filter(item=self.item).count() == 2)

--- a/oh_staff_ui/tests.py
+++ b/oh_staff_ui/tests.py
@@ -57,6 +57,8 @@ from oh_staff_ui.views_utils import (
     get_records_oai,
     get_bad_arg_error_xml,
     get_bad_verb_error_xml,
+    delete_file_and_children,
+    delete_file_from_filesystem,
 )
 from oh_staff_ui.management.commands.reprocess_derivative_images import (
     reprocess_derivative_images,
@@ -1699,6 +1701,133 @@ class ReprocessDerivativeImagesTestCase(TestCase):
         )
         self.assertTrue(thumbnail_path.is_file())
         self.assertTrue(submaster_path.is_file())
+
+    def tearDown(self) -> None:
+        media_files = MediaFile.objects.filter(item=self.item)
+        # delete files on disk first
+        for mf in media_files:
+            if mf.file:
+                mf.file.delete()
+        # delete MediaFile objects starting with the parent - CASCADE will delete children
+        for parent_mf in media_files.filter(parent__isnull=True):
+            parent_mf.delete()
+
+
+class FileDeletionTestCase(TestCase):
+    fixtures = [
+        "item-status-data.json",
+        "item-type-data.json",
+        "media-file-type-data.json",
+    ]
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = User.objects.create_user("tester")
+        cls.mock_request = HttpRequest()
+        cls.mock_request.user = User.objects.get(username=cls.user.username)
+
+    def create_master_and_derivatives(self, user, mock_request):
+        item = ProjectItem.objects.create(
+            ark="fake/abcdef",
+            created_by=user,
+            last_modified_by=user,
+            title="Fake title",
+            type=ItemType.objects.get(type="Audio"),
+        )
+        file_type = MediaFileType.objects.get(file_code="image_master")
+        master_image_file = OralHistoryFile(
+            item.id,
+            "samples/sample_marbles.tif",
+            file_type,
+            "master",
+            mock_request,
+        )
+
+        handler = ImageFileHandler(master_image_file)
+        handler.process_files()
+
+        # get created date from derivative images, so we can check if they are updated
+        thumbnail_create_date = MediaFile.objects.get(
+            item=item, file_type__file_code="image_thumbnail"
+        ).create_date
+        submaster_create_date = MediaFile.objects.get(
+            item=item, file_type__file_code="image_submaster"
+        ).create_date
+
+        return item, thumbnail_create_date, submaster_create_date
+
+    def test_delete_file_and_children(self):
+        self.item, self.thumbnail_created_date, self.submaster_created_date = (
+            self.create_master_and_derivatives(self.user, self.mock_request)
+        )
+
+        # check that the thumbnail and submaster images are created
+        self.assertTrue(MediaFile.objects.filter(item=self.item).count() == 3)
+
+        # check that the thumbnail and submaster images exist on disk
+        thumbnail_path = thumbnail_path = Path(
+            f"{settings.MEDIA_ROOT}/oh_static/nails/fake-abcdef-1-thumbnail.jpg"
+        )
+        submaster_path = Path(
+            f"{settings.MEDIA_ROOT}/oh_static/submasters/fake-abcdef-1-submaster.jpg"
+        )
+        self.assertTrue(thumbnail_path.is_file())
+        self.assertTrue(submaster_path.is_file())
+
+        # get our master Mediafile
+        image_mediafile = MediaFile.objects.get(
+            item=self.item, file_type__file_code="image_master"
+        )
+        # delete Master and derivative files
+        delete_file_and_children(image_mediafile)
+
+        # check that all 3 MediaFiles are deleted
+        self.assertFalse(MediaFile.objects.filter(item=self.item).exists())
+        # check that the files on disk are deleted
+        self.assertFalse(thumbnail_path.is_file())
+        self.assertFalse(submaster_path.is_file())
+
+    def test_delete_file_and_children_no_children(self):
+        self.item = ProjectItem.objects.create(
+            ark="fake/abcdef",
+            created_by=self.user,
+            last_modified_by=self.user,
+            title="Fake title",
+            type=ItemType.objects.get(type="Audio"),
+        )
+        file_type = MediaFileType.objects.get(file_code="image_master")
+        master_image_file = OralHistoryFile(
+            self.item.id,
+            "samples/sample_marbles.tif",
+            file_type,
+            "master",
+            self.mock_request,
+        )
+
+        handler = ImageFileHandler(master_image_file)
+        handler.process_files()
+
+        # check that the thumbnail and submaster images are created
+        self.assertTrue(MediaFile.objects.filter(item=self.item).count() == 3)
+
+        submaster_mediafile = MediaFile.objects.get(
+            item=self.item, file_type__file_code="image_submaster"
+        )
+        # delete files
+        delete_file_and_children(submaster_mediafile)
+
+        # check that master and thumbnail files are still there (in DB and on disk)
+        self.assertTrue(MediaFile.objects.filter(item=self.item).count() == 2)
+        thumbnail_path = Path(
+            f"{settings.MEDIA_ROOT}/oh_static/nails/fake-abcdef-1-thumbnail.jpg"
+        )
+        self.assertTrue(thumbnail_path.is_file())
+
+        # check that the submaster file is deleted
+        submaster_path = Path(
+            f"{settings.MEDIA_ROOT}/oh_static/submasters/fake-abcdef-1-submaster.jpg"
+        )
+        self.assertFalse(submaster_path.is_file())
 
     def tearDown(self) -> None:
         media_files = MediaFile.objects.filter(item=self.item)

--- a/oh_staff_ui/tests.py
+++ b/oh_staff_ui/tests.py
@@ -58,7 +58,6 @@ from oh_staff_ui.views_utils import (
     get_bad_arg_error_xml,
     get_bad_verb_error_xml,
     delete_file_and_children,
-    delete_file_from_filesystem,
 )
 from oh_staff_ui.management.commands.reprocess_derivative_images import (
     reprocess_derivative_images,

--- a/oh_staff_ui/urls.py
+++ b/oh_staff_ui/urls.py
@@ -17,6 +17,7 @@ urlpatterns = [
     path("logs/", views.show_log, name="show_log"),
     path("logs/<int:line_count>", views.show_log, name="show_log"),
     path("upload_file/<int:item_id>", views.upload_file, name="upload_file"),
+    path("delete_file/<int:file_id>", views.delete_file, name="delete_file"),
     path("order_files/<int:item_id>", views.order_files, name="order_files"),
     path("browse/", views.browse, name="browse"),
     # Allow access to download media files via built-in view django.views.static.serve()

--- a/oh_staff_ui/views.py
+++ b/oh_staff_ui/views.py
@@ -137,7 +137,8 @@ def upload_file(request: HttpRequest, item_id: int) -> HttpResponse:
     files = MediaFile.objects.filter(item=item).order_by(
         "sequence", "file_type__file_code"
     )
-    # get the child (derivative) files for each file
+    # add "children" attribute to each file to hold its derivatives
+    # this is used in the template to display child files before deletion
     for file in files:
         file.children = list(MediaFile.objects.filter(parent=file))
     file_errors = MediaFileError.objects.filter(item=item).order_by("create_date")

--- a/oh_staff_ui/views.py
+++ b/oh_staff_ui/views.py
@@ -195,7 +195,7 @@ def upload_file(request: HttpRequest, item_id: int) -> HttpResponse:
 def delete_file(request: HttpRequest, file_id: int) -> HttpResponse:
     media_file = MediaFile.objects.get(pk=file_id)
     item_id = media_file.item.pk
-    delete_file_and_children(media_file)
+    delete_file_and_children(media_file, request.user)
     return redirect("upload_file", item_id=item_id)
 
 

--- a/oh_staff_ui/views_utils.py
+++ b/oh_staff_ui/views_utils.py
@@ -635,7 +635,7 @@ def delete_file(media_file: MediaFile, user: User) -> None:
         media_file.file.delete()
     else:
         logger.warning(
-            f"File {media_file.file.name} does not exist on the file system."
+            f"File {file_name} does not exist on the file system; deleting media object anyhow."
         )
     logger.info(f"File {file_name} deleted by user {user}.")
     media_file.delete()

--- a/oh_staff_ui/views_utils.py
+++ b/oh_staff_ui/views_utils.py
@@ -624,12 +624,14 @@ def delete_file_and_children(media_file: MediaFile) -> None:
         # first delete file from file system
         if child.file:
             delete_file_from_filesystem(child.file.name)
+            child.file.delete()
         else:
             logger.warning(f"File {child.file_name} does not exist on the file system.")
         child.delete()
     # then delete the file (and its file from file system)
     if media_file.file:
         delete_file_from_filesystem(media_file.file.name)
+        media_file.file.delete()
     else:
         logger.warning(
             f"File {media_file.file_name} does not exist on the file system."

--- a/oh_staff_ui/views_utils.py
+++ b/oh_staff_ui/views_utils.py
@@ -9,6 +9,7 @@ from django.conf import settings
 from django.contrib import messages
 from django.core.management import call_command
 from django.db.models import CharField, Model, Q, QuerySet
+from django.contrib.auth.models import User
 from django.forms import BaseFormSet, Form, formset_factory
 from django.http.request import HttpRequest  # for code completion
 from django.utils import timezone
@@ -608,3 +609,7 @@ def add_oai_envelope_to_mods(ohmods: OralHistoryMods) -> etree.Element:
     record_el.append(metadata_el)
 
     return record_el
+
+
+def user_in_oh_staff_group(user: User) -> bool:
+    return user.groups.filter(name="Oral History Staff").exists()

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1,113 +1,129 @@
 ul.navbar {
-    list-style-type: none;
-    margin: 0;
-    padding: 0;
-    overflow: hidden;
-    background-color: #d0d0d7;
-    border: 1px solid black;
-    justify-content: unset;
-}
-  
-.navbar li {
-    float: left;
-    border-right: 1px solid #bcbcc5;
-}
-  
-.navbar li a {
-    display: block;
-    text-align: center;
-    padding: 10px 12px;
-    text-decoration: none;
+  list-style-type: none;
+  margin: 0;
+  padding: 0;
+  overflow: hidden;
+  background-color: #d0d0d7;
+  border: 1px solid black;
+  justify-content: unset;
 }
 
-td.search-type{
-    min-width: 15rem
+.navbar li {
+  float: left;
+  border-right: 1px solid #bcbcc5;
+}
+
+.navbar li a {
+  display: block;
+  text-align: center;
+  padding: 10px 12px;
+  text-decoration: none;
+}
+
+td.search-type {
+  min-width: 15rem;
 }
 
 .current-item {
-    font-weight: bold;
+  font-weight: bold;
 }
 
 td.label,
 td.qualifier {
-    vertical-align: baseline;
+  vertical-align: baseline;
 }
 
 td.label {
-    white-space: nowrap;
+  white-space: nowrap;
 }
 
 td.qualifier {
-    min-width: 15rem
+  min-width: 15rem;
 }
 
 .empty_form {
-    display: none;
+  display: none;
 }
 
 .box {
-    margin: 10px;
-    padding: 10px;
-    border: 1px solid black;
+  margin: 10px;
+  padding: 10px;
+  border: 1px solid black;
 }
 /* .file_metadata: optional metadata on edit_item page
 for Audio and Video items. Hide all table rows other 
-than Description. */ 
+than Description. */
 table.file_metadata tr:not([class*="description"]) {
-    display: none;
+  display: none;
 }
 /* for file-level metadata, hide all dropdown options
-other than TableOfContents (value = "3") */ 
-.file_metadata .description select option:not([value="3"]){
-    display: none;
+other than TableOfContents (value = "3") */
+.file_metadata .description select option:not([value="3"]) {
+  display: none;
 }
 
-.header-metadata{
-    border-collapse: collapse;
- }
- 
-.header-metadata td{
-    padding: 4px;
-    border: 1px solid;
-    vertical-align: top;
+.header-metadata {
+  border-collapse: collapse;
+}
+
+.header-metadata td {
+  padding: 4px;
+  border: 1px solid;
+  vertical-align: top;
 }
 
 ul.tree {
-    margin-top: -10px;
+  margin-top: -10px;
 }
 
 caption {
-    font-weight: bold;
-    color: black;
+  font-weight: bold;
+  color: black;
 }
 
 .add_formset {
-    --bs-btn-padding-x: 0.5rem;
-    --bs-btn-padding-y: 0.1rem;
+  --bs-btn-padding-x: 0.5rem;
+  --bs-btn-padding-y: 0.1rem;
 }
 
 /* Override bootstrap to reduce vertical space in tall forms*/
 .mb-3 {
-    margin-bottom: .4rem !important;
-  }
+  margin-bottom: 0.4rem !important;
+}
 
 /* Workarounds for "bootstrap_form success_css_class" not working  */
 /* CSS class "is-valid" is incorrectly applied to bound forms. */
 /* These four rules remove undesired checkmarks and green border styling. */
 .form-control {
-    background-image: none !important;
-    border-color: var(--bs-border-color) !important;
+  background-image: none !important;
+  border-color: var(--bs-border-color) !important;
 }
 /* background-image is caret, copied from regular bootstrap select */
 .form-select.is-valid {
-    background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3e%3cpath fill='none' stroke='%23343a40' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='m2 5 6 6 6-6'/%3e%3c/svg%3e") !important;
-    border-color: var(--bs-border-color) !important;
+  background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3e%3cpath fill='none' stroke='%23343a40' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='m2 5 6 6 6-6'/%3e%3c/svg%3e") !important;
+  border-color: var(--bs-border-color) !important;
 }
 
 .form-select.is-valid:focus {
-    box-shadow: 0 0 0 .25rem rgba(13,110,253,.25) !important;
+  box-shadow: 0 0 0 0.25rem rgba(13, 110, 253, 0.25) !important;
 }
 
 .form-control:focus {
-    box-shadow: 0 0 0 .25rem rgba(13,110,253,.25) !important;
+  box-shadow: 0 0 0 0.25rem rgba(13, 110, 253, 0.25) !important;
+}
+
+.confirm-delete-popup {
+  display: none;
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  width: 800px;
+  height: 150px;
+  margin-top: -75px;
+  margin-left: -400px;
+  padding: 20px;
+  border: 1px solid black;
+  background-color: #d0d0d7;
+  text-align: center;
+  z-index: 1;
 }

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -71,6 +71,9 @@ other than TableOfContents (value = "3") */
   border: 1px solid;
   vertical-align: top;
 }
+.header-metadata th {
+  padding-right: 10px;
+}
 
 ul.tree {
   margin-top: -10px;
@@ -118,12 +121,17 @@ caption {
   top: 50%;
   left: 50%;
   width: 800px;
-  height: 150px;
-  margin-top: -75px;
+  height: auto;
+  min-height: 150px;
+  margin-top: -100px;
   margin-left: -400px;
   padding: 20px;
   border: 1px solid black;
   background-color: #d0d0d7;
   text-align: center;
   z-index: 1;
+}
+
+.confirm-delete-popup ul {
+  list-style-type: none;
 }

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -1,104 +1,116 @@
 let buttons = document.querySelectorAll("button.add_formset");
-buttons.forEach(btn => btn.addEventListener("click", showEmptyForm));
+buttons.forEach((btn) => btn.addEventListener("click", showEmptyForm));
 
 function showEmptyForm(event) {
-    // Prevent button default behavior of submitting form.
-    event.preventDefault();
-    
-    // Get metadata type from button id (e.g., name_add -> name).
-    metadataType = this.id.replace("_add", "");
-    
-    // Find current number of forms being used for this type.
-    // This comes from the hidden "management form" for the given type.
-    // E.g., id_names_TOTAL_FORMS
-    totalId = `id_${metadataType}s-TOTAL_FORMS`;
-    total = document.getElementById(totalId);
+  // Prevent button default behavior of submitting form.
+  event.preventDefault();
 
-    // Find empty form for this type.
-    // E.g., name -> name_empty_form
-    emptyForm = document.getElementById(metadataType + "_empty_form");
-    
-    // Clone it to make a new form for display.
-    newForm = emptyForm.cloneNode(deep=true);
-    
-    // Update numeric prefix values for new form, using original total.
-    // E.g., for the new 2nd form (0-based):
-    // names-__prefix__-usage_id -> names-1-usage_id
-    newFormNumber = total.value;
-    newForm.innerHTML = newForm.innerHTML.replace(/__prefix__/g, newFormNumber);
-    
-    // Remove id & class, copied from emptyForm
-    newForm.removeAttribute("id");
-    newForm.classList.remove("empty_form");
-    // add a new class with name of metadataType
-    // used to prevent hiding new Description rows on file-level items
-    newForm.classList.add(metadataType);
-    
-    // Display the new form immediately before the (hidden) empty form.
-    emptyForm.parentNode.insertBefore(newForm, emptyForm);
-    
-    // Finally, increment total forms for this type.
-    // E.g., if there are now 2 name forms, value will change from 1 -> 2.
-    total.value = Number(total.value) + 1;
+  // Get metadata type from button id (e.g., name_add -> name).
+  metadataType = this.id.replace("_add", "");
+
+  // Find current number of forms being used for this type.
+  // This comes from the hidden "management form" for the given type.
+  // E.g., id_names_TOTAL_FORMS
+  totalId = `id_${metadataType}s-TOTAL_FORMS`;
+  total = document.getElementById(totalId);
+
+  // Find empty form for this type.
+  // E.g., name -> name_empty_form
+  emptyForm = document.getElementById(metadataType + "_empty_form");
+
+  // Clone it to make a new form for display.
+  newForm = emptyForm.cloneNode((deep = true));
+
+  // Update numeric prefix values for new form, using original total.
+  // E.g., for the new 2nd form (0-based):
+  // names-__prefix__-usage_id -> names-1-usage_id
+  newFormNumber = total.value;
+  newForm.innerHTML = newForm.innerHTML.replace(/__prefix__/g, newFormNumber);
+
+  // Remove id & class, copied from emptyForm
+  newForm.removeAttribute("id");
+  newForm.classList.remove("empty_form");
+  // add a new class with name of metadataType
+  // used to prevent hiding new Description rows on file-level items
+  newForm.classList.add(metadataType);
+
+  // Display the new form immediately before the (hidden) empty form.
+  emptyForm.parentNode.insertBefore(newForm, emptyForm);
+
+  // Finally, increment total forms for this type.
+  // E.g., if there are now 2 name forms, value will change from 1 -> 2.
+  total.value = Number(total.value) + 1;
 }
 
 // Disable file upload submit button once clicked.
 // The button is restored to normal once Django completes processing and re-renders the form.
 function disable_upload_button(form) {
-	btn = form.elements.upload_button;
-	btn.textContent = "Please wait...";
-	btn.disabled = true;
+  btn = form.elements.upload_button;
+  btn.textContent = "Please wait...";
+  btn.disabled = true;
 }
 
 if (document.getElementById("item_search")) {
-    // Hide Status field label by default since Title is default search type
-    labels = document.getElementsByTagName("label");
-    for (let i = 0; i < labels.length; i++) {
-        if (labels[i].getAttribute("for") == "id_status_query") {
-            labels[i].style.display = "none";
-        }
+  // Hide Status field label by default since Title is default search type
+  labels = document.getElementsByTagName("label");
+  for (let i = 0; i < labels.length; i++) {
+    if (labels[i].getAttribute("for") == "id_status_query") {
+      labels[i].style.display = "none";
     }
+  }
 
-    // Dynamically update available fields in item search form
-    document.getElementById("id_search_type").onchange = function(){
-        // for Status search, hide char query and make status visible
-        if (this.value == "status") {
-            document.getElementsByClassName("status-query")[0].style.display = "";
-            document.getElementsByClassName("char-query")[0].type = "hidden";
-            for (let i = 0; i < labels.length; i++) {
-                if (labels[i].getAttribute("for") == "id_char_query") {
-                    labels[i].style.display = "none";
-                }
-                if (labels[i].getAttribute("for") == "id_status_query") {
-                    labels[i].style.display = "";
-                }
-            }
+  // Dynamically update available fields in item search form
+  document.getElementById("id_search_type").onchange = function () {
+    // for Status search, hide char query and make status visible
+    if (this.value == "status") {
+      document.getElementsByClassName("status-query")[0].style.display = "";
+      document.getElementsByClassName("char-query")[0].type = "hidden";
+      for (let i = 0; i < labels.length; i++) {
+        if (labels[i].getAttribute("for") == "id_char_query") {
+          labels[i].style.display = "none";
         }
-        // for all other searches, hide status and make char visible
-        else {
-            document.getElementsByClassName("status-query")[0].style.display = "none";
-            document.getElementsByClassName("char-query")[0].type = "";
-            for (let i = 0; i < labels.length; i++) {
-                if (labels[i].getAttribute("for") == "id_char_query") {
-                    labels[i].style.display = "";
-                }
-                if (labels[i].getAttribute("for") == "id_status_query") {
-                    labels[i].style.display = "none";
-                }
-            }
+        if (labels[i].getAttribute("for") == "id_status_query") {
+          labels[i].style.display = "";
         }
+      }
     }
+    // for all other searches, hide status and make char visible
+    else {
+      document.getElementsByClassName("status-query")[0].style.display = "none";
+      document.getElementsByClassName("char-query")[0].type = "";
+      for (let i = 0; i < labels.length; i++) {
+        if (labels[i].getAttribute("for") == "id_char_query") {
+          labels[i].style.display = "";
+        }
+        if (labels[i].getAttribute("for") == "id_status_query") {
+          labels[i].style.display = "none";
+        }
+      }
+    }
+  };
 }
 
 // styling for "add item" page
 if (window.location.href.endsWith("add_item/")) {
-    // hide parent dropdown
-    document.getElementById("id_parent").style.display = "none";
-    // find and hide label for parent dropdown
-    labels = document.getElementsByTagName("label");
-    for (let i = 0; i < labels.length; i++) {
-        if (labels[i].getAttribute("for") == "id_parent") {
-            labels[i].style.display = "none";
-        }
+  // hide parent dropdown
+  document.getElementById("id_parent").style.display = "none";
+  // find and hide label for parent dropdown
+  labels = document.getElementsByTagName("label");
+  for (let i = 0; i < labels.length; i++) {
+    if (labels[i].getAttribute("for") == "id_parent") {
+      labels[i].style.display = "none";
     }
+  }
+}
+
+function showConfirmDeletePopup(fileID) {
+  fullID = "confirm-delete-popup-" + fileID;
+  document.getElementById(fullID).style.display = "block";
+  // set focus to "Cancel" button
+  document.getElementById("cancel-" + fileID).focus();
+}
+
+function hideConfirmDeletePopup(fileID) {
+  fullID = "confirm-delete-popup-" + fileID;
+  document.getElementById(fullID).style.display = "none";
 }


### PR DESCRIPTION
Implements [SYS-1598](https://uclalibrary.atlassian.net/browse/SYS-1598), which absorbed [SYS-1599](https://uclalibrary.atlassian.net/browse/SYS-1599)

This PR allows users to delete files (both Master and derivative) from item records. Users in the Oral History Staff user group will see a new column in the "File Information" table on `/upload_file/` pages containing a delete button for every file. When clicked, this button brings up a popup asking the user to confirm deletion of the selected file and its children (if any). If "Yes" is selected in this popup, the new `delete_file()` view is called and the relevant MediaFile(s), File object(s), and file(s) on disk are deleted. 

Also includes release note and tag bump for deployment, and two new tests for the new `delete_file_and_children()` function in `views_utils.py`. 

Screenshot:
<img width="1350" alt="image" src="https://github.com/UCLALibrary/oral-history-staff-ui/assets/7283991/c2390f65-e657-4726-ad70-0ab973cdcb09">


[SYS-1598]: https://uclalibrary.atlassian.net/browse/SYS-1598?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SYS-1599]: https://uclalibrary.atlassian.net/browse/SYS-1599?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ