### PR TITLE
SYS-1614: Fix orientation problem with images

### DIFF
--- a/charts/prod-ohstaff-values.yaml
+++ b/charts/prod-ohstaff-values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: uclalibrary/oral-history-staff-ui
-  tag: v1.1.2
+  tag: v1.1.3
   pullPolicy: Always
 
 nameOverride: ""

--- a/oh_staff_ui/templates/oh_staff_ui/release_notes.html
+++ b/oh_staff_ui/templates/oh_staff_ui/release_notes.html
@@ -4,6 +4,12 @@
 <h3>Release Notes</h3>
 <hr/>
 
+<h4>1.1.3</h4>
+<p><i>May 14, 2024</i></p>
+<ul>
+   <li>Fixed bug where derivative images with non-default orientation were not handled correctly.</li>
+</ul>
+
 <h4>1.1.2</h4>
 <p><i>May 8, 2024</i></p>
 <ul>


### PR DESCRIPTION
Fixes [SYS-1614](https://uclalibrary.atlassian.net/browse/SYS-1614).  Bumps version to `v1.1.3`  for deployment.

This PR fixes a bug in the `ImageFileHandler` class.  It was not accounting for non-default orientation as indicated by EXIF data.  This resulted in derivative images also having non-default orientation, usually rotated 90 degrees clockwise or counter-clockwise.  It only applied to about a dozen images, but those which are published to the public site looked bad.

The `ImageFileHandler` fix is not retroactive, so I'll need to copy a targeted fix-it script to the production environment and run it there.


[SYS-1614]: https://uclalibrary.atlassian.net/browse/SYS-1614?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ