### PR TITLE
SYS-1098: Add file audit management command

### DIFF
--- a/charts/prod-ohstaff-values.yaml
+++ b/charts/prod-ohstaff-values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: uclalibrary/oral-history-staff-ui
-  tag: v1.1.3
+  tag: v1.1.4
   pullPolicy: Always
 
 nameOverride: ""

--- a/oh_staff_ui/management/commands/audit_media_files.py
+++ b/oh_staff_ui/management/commands/audit_media_files.py
@@ -1,6 +1,6 @@
 import logging
 from pathlib import Path
-from django.core.management.base import BaseCommand, CommandParser
+from django.core.management.base import BaseCommand, CommandParser, CommandError
 from django.conf import settings
 from oh_staff_ui.models import MediaFile
 
@@ -15,7 +15,8 @@ class Command(BaseCommand):
         parser.add_argument(
             "mode",
             type=str,
-            help="Mode: one of DB|FILES|BOTH",
+            help="Mode: one of DB|FILES|ALL",
+            choices=["DB", "FILES", "ALL"],
         )
 
     def handle(self, *args, **options) -> None:
@@ -28,7 +29,7 @@ class Command(BaseCommand):
             self._compare_db_to_files()
             self._compare_files_to_db()
         else:
-            raise ValueError(f"Unknown mode: {mode}")
+            raise CommandError(f"Unknown mode: {mode}")
 
     def _compare_db_to_files(self) -> None:
         """Compares MediaFile data with files on disk and
@@ -39,7 +40,7 @@ class Command(BaseCommand):
             db_file_name = mf.file.name
             db_file_path = Path(settings.MEDIA_ROOT).joinpath(db_file_name)
             db_file_size = mf.file_size
-            # If file does exist, get info for comparison
+            # If file does exist, get info for comparison.
             if db_file_path.exists():
                 disk_file_size = db_file_path.stat().st_size
             else:
@@ -49,12 +50,12 @@ class Command(BaseCommand):
             if not db_file_path.exists():
                 logger.warning(
                     f"FILE MISSING:\t{db_file_path}\t{disk_file_path}\t"
-                    f"{db_file_size}\t{disk_file_size}"
+                    f"{db_file_size}\t{disk_file_size}\t{mf.item_id}"
                 )
             elif db_file_size != disk_file_size:
                 logger.warning(
                     f"SIZE DIFFERENCE:\t{db_file_path}\t{disk_file_path}\t"
-                    f"{db_file_size}\t{disk_file_size}"
+                    f"{db_file_size}\t{disk_file_size}\t{mf.item_id}"
                 )
 
     def _compare_files_to_db(self) -> None:
@@ -63,22 +64,24 @@ class Command(BaseCommand):
         """
         # Build this once, as it will be used many times.
         media_root = settings.MEDIA_ROOT + "/"
-        # rglob returns directory and file names.
         for path in Path(media_root).rglob("*"):
+            # rglob returns directory and file names; we only want files.
             if path.is_file():
-                # MediaFile file.name does not have MEDIA_ROOT prefix, so remove it.
+                # MediaFile file.name does not have MEDIA_ROOT prefix,
+                # so remove it from disk file name.
                 disk_file_path = str(path).replace(media_root, "")
                 disk_file_size = path.stat().st_size
                 media_files = MediaFile.objects.filter(file=disk_file_path)
                 media_file_count = len(media_files)
 
                 if media_file_count == 0:
-                    # File not found in database
+                    # File not found in database.
                     db_file_size = None
                     db_file_path = "NOT FOUND"
+                    item_id = None
                     logger.warning(
                         f"DB MISSING:\t{db_file_path}\t{disk_file_path}\t"
-                        f"{db_file_size}\t{disk_file_size}"
+                        f"{db_file_size}\t{disk_file_size}\t{item_id}"
                     )
                 elif media_file_count > 1:
                     # Shouldn't happen due to custom MediaFile.save()...
@@ -87,5 +90,5 @@ class Command(BaseCommand):
                     for mf in media_files:
                         logger.warning(
                             f"MULTIPLE:\t{mf.file.name}\t{disk_file_path}\t"
-                            f"{mf.file_size}\t{disk_file_size}"
+                            f"{mf.file_size}\t{disk_file_size}\t{mf.item_id}"
                         )

--- a/oh_staff_ui/management/commands/audit_media_files.py
+++ b/oh_staff_ui/management/commands/audit_media_files.py
@@ -1,0 +1,91 @@
+import logging
+from pathlib import Path
+from django.core.management.base import BaseCommand, CommandParser
+from django.conf import settings
+from oh_staff_ui.models import MediaFile
+
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    help = "Django management command to audit media files."
+
+    def add_arguments(self, parser: CommandParser) -> None:
+        parser.add_argument(
+            "mode",
+            type=str,
+            help="Mode: one of DB|FILES|BOTH",
+        )
+
+    def handle(self, *args, **options) -> None:
+        mode = options["mode"]
+        if mode == "DB":
+            self._compare_db_to_files()
+        elif mode == "FILES":
+            self._compare_files_to_db()
+        elif mode == "ALL":
+            self._compare_db_to_files()
+            self._compare_files_to_db()
+        else:
+            raise ValueError(f"Unknown mode: {mode}")
+
+    def _compare_db_to_files(self) -> None:
+        """Compares MediaFile data with files on disk and
+        reports differences.
+        """
+        media_files = MediaFile.objects.all().order_by("id")
+        for mf in media_files:
+            db_file_name = mf.file.name
+            db_file_path = Path(settings.MEDIA_ROOT).joinpath(db_file_name)
+            db_file_size = mf.file_size
+            # If file does exist, get info for comparison
+            if db_file_path.exists():
+                disk_file_size = db_file_path.stat().st_size
+            else:
+                disk_file_size = None
+                disk_file_path = "NOT FOUND"
+            # Report on differences only, for now.
+            if not db_file_path.exists():
+                logger.warning(
+                    f"FILE MISSING:\t{db_file_path}\t{disk_file_path}\t"
+                    f"{db_file_size}\t{disk_file_size}"
+                )
+            elif db_file_size != disk_file_size:
+                logger.warning(
+                    f"SIZE DIFFERENCE:\t{db_file_path}\t{disk_file_path}\t"
+                    f"{db_file_size}\t{disk_file_size}"
+                )
+
+    def _compare_files_to_db(self) -> None:
+        """Compares files on disk with MediaFile data and
+        reports differences.
+        """
+        # Build this once, as it will be used many times.
+        media_root = settings.MEDIA_ROOT + "/"
+        # rglob returns directory and file names.
+        for path in Path(media_root).rglob("*"):
+            if path.is_file():
+                # MediaFile file.name does not have MEDIA_ROOT prefix, so remove it.
+                disk_file_path = str(path).replace(media_root, "")
+                disk_file_size = path.stat().st_size
+                media_files = MediaFile.objects.filter(file=disk_file_path)
+                media_file_count = len(media_files)
+
+                if media_file_count == 0:
+                    # File not found in database
+                    db_file_size = None
+                    db_file_path = "NOT FOUND"
+                    logger.warning(
+                        f"DB MISSING:\t{db_file_path}\t{disk_file_path}\t"
+                        f"{db_file_size}\t{disk_file_size}"
+                    )
+                elif media_file_count > 1:
+                    # Shouldn't happen due to custom MediaFile.save()...
+                    # but check for file found multiple times in database.
+                    # Some/all/none may actually be right, so report all.
+                    for mf in media_files:
+                        logger.warning(
+                            f"MULTIPLE:\t{mf.file.name}\t{disk_file_path}\t"
+                            f"{mf.file_size}\t{disk_file_size}"
+                        )

--- a/oh_staff_ui/templates/oh_staff_ui/release_notes.html
+++ b/oh_staff_ui/templates/oh_staff_ui/release_notes.html
@@ -4,6 +4,12 @@
 <h3>Release Notes</h3>
 <hr/>
 
+<h4>1.1.4</h4>
+<p><i>May 21, 2024</i></p>
+<ul>
+   <li>Added command to compare database and disk information about media files.</li>
+</ul>
+
 <h4>1.1.3</h4>
 <p><i>May 14, 2024</i></p>
 <ul>


### PR DESCRIPTION
Implements [SYS-1098](https://uclalibrary.atlassian.net/browse/SYS-1098).  Bumps version to `v1.1.4` for deployment.

This PR adds a management command, `audit_media_files`.  It compares information about media files and reports differences via the application log.  It takes one mandatory argument:
* `DB`: Check all `MediaFile` objects and report on any where the real file pointed to does not exist, or has a different size from what's in the database
* 'FILES': Check all real files in `MEDIA_ROOT` (and all subdirectories) and report on any where there is no corresponding `MediaFile` object
  * Also reports if there are multiple `MediaFile` objects matching the real file, which should not happen but... who knows?
* `ALL`: Runs both the `DB` and the `FILES` audits

Mismatches are reported via `logs/application.log` and look like this:
```
# From the DB audit
WARNING 2024-05-20 16:17:51,544 oh_staff_ui.management.commands.audit_media_files audit_media_files FILE MISSING:       secret_media/oh_masters/pdf/masters/21198-zz0008z797-1-master.pdf       NOT FOUND       101709244       None    631

# From the FILES audit
WARNING 2024-05-20 16:17:53,736 oh_staff_ui.management.commands.audit_media_files audit_media_files DB MISSING: NOT FOUND       oh_static/nails/21198-zz002k355g-1-thumbnail.jpg        None    8189    None
```

For review after collecting data:
```
# Select the relevant log messages, and output just fields 6 to the end of line (space-delimited)
$ grep audit_media_files logs/application.log | cut -d" " -f6- > audit_trial.txt

FILE MISSING:       secret_media/oh_masters/pdf/masters/21198-zz0008z797-1-master.pdf       NOT FOUND       101709244       None    631

DB MISSING: NOT FOUND       oh_static/nails/21198-zz002k355g-1-thumbnail.jpg        None    8189    None
```
Remaining data is 6 fields, tab-delimited:
1. Description
2. DB file path, from `MediaFile.file.name`
3. Disk file path
4. DB file size, from `MediaFile.file_size`
5. Disk file size
6. Item id, from `MediaFile.item_id`

#### Testing
I chose not to write any tests. This command does not modify data, and outputs everything to a log file, and I opted not to contort things to make it testable. 

I tested it locally in 2 ways:
1. Using master and derivative images downloaded & generated during the image orientation review and cleanup, with all other `MediaFile` entries deleted from local database.  I confirmed that with this limited set, no discrepancies were found.  Then I manually renamed one file on disk (so it differed from its `MediaFile` data), and the script reported this difference correctly.
2. I imported a recent full production database dump locally.  The script reported 24,447 differences... since the vast majority of real files are **not** on my local system, and the image derivatives I generated locally have different sequence numbers from production, almost nothing matched.  This is expected.

So... please review the logic, make sure the command runs for you, and that should be enough.



[SYS-1098]: https://uclalibrary.atlassian.net/browse/SYS-1098?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ