### PR TITLE
SYS-1098: Limit audit_media_files scan to master and derivative directories

### DIFF
--- a/charts/prod-ohstaff-values.yaml
+++ b/charts/prod-ohstaff-values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: uclalibrary/oral-history-staff-ui
-  tag: v1.1.4
+  tag: v1.1.5
   pullPolicy: Always
 
 nameOverride: ""

--- a/oh_staff_ui/management/commands/audit_media_files.py
+++ b/oh_staff_ui/management/commands/audit_media_files.py
@@ -64,31 +64,33 @@ class Command(BaseCommand):
         """
         # Build this once, as it will be used many times.
         media_root = settings.MEDIA_ROOT + "/"
-        for path in Path(media_root).rglob("*"):
-            # rglob returns directory and file names; we only want files.
-            if path.is_file():
-                # MediaFile file.name does not have MEDIA_ROOT prefix,
-                # so remove it from disk file name.
-                disk_file_path = str(path).replace(media_root, "")
-                disk_file_size = path.stat().st_size
-                media_files = MediaFile.objects.filter(file=disk_file_path)
-                media_file_count = len(media_files)
+        # Check only these top-level directories in media_root.
+        for file_dir in [settings.OH_MASTERS, settings.OH_STATIC, settings.OH_WOWZA]:
+            for path in Path(media_root + file_dir + "/").rglob("*"):
+                # rglob returns directory and file names; we only want files.
+                if path.is_file():
+                    # MediaFile file.name does not have MEDIA_ROOT prefix,
+                    # so remove it from disk file name.
+                    disk_file_path = str(path).replace(media_root, "")
+                    disk_file_size = path.stat().st_size
+                    media_files = MediaFile.objects.filter(file=disk_file_path)
+                    media_file_count = len(media_files)
 
-                if media_file_count == 0:
-                    # File not found in database.
-                    db_file_size = None
-                    db_file_path = "NOT FOUND"
-                    item_id = None
-                    logger.warning(
-                        f"DB MISSING:\t{db_file_path}\t{disk_file_path}\t"
-                        f"{db_file_size}\t{disk_file_size}\t{item_id}"
-                    )
-                elif media_file_count > 1:
-                    # Shouldn't happen due to custom MediaFile.save()...
-                    # but check for file found multiple times in database.
-                    # Some/all/none may actually be right, so report all.
-                    for mf in media_files:
+                    if media_file_count == 0:
+                        # File not found in database.
+                        db_file_size = None
+                        db_file_path = "NOT FOUND"
+                        item_id = None
                         logger.warning(
-                            f"MULTIPLE:\t{mf.file.name}\t{disk_file_path}\t"
-                            f"{mf.file_size}\t{disk_file_size}\t{mf.item_id}"
+                            f"DB MISSING:\t{db_file_path}\t{disk_file_path}\t"
+                            f"{db_file_size}\t{disk_file_size}\t{item_id}"
                         )
+                    elif media_file_count > 1:
+                        # Shouldn't happen due to custom MediaFile.save()...
+                        # but check for file found multiple times in database.
+                        # Some/all/none may actually be right, so report all.
+                        for mf in media_files:
+                            logger.warning(
+                                f"MULTIPLE:\t{mf.file.name}\t{disk_file_path}\t"
+                                f"{mf.file_size}\t{disk_file_size}\t{mf.item_id}"
+                            )

--- a/oh_staff_ui/templates/oh_staff_ui/release_notes.html
+++ b/oh_staff_ui/templates/oh_staff_ui/release_notes.html
@@ -4,6 +4,12 @@
 <h3>Release Notes</h3>
 <hr/>
 
+<h4>1.1.5</h4>
+<p><i>May 21, 2024</i></p>
+<ul>
+   <li>Limited <code>audit_media_files</code> scan to master and derivative directories.</li>
+</ul>
+
 <h4>1.1.4</h4>
 <p><i>May 21, 2024</i></p>
 <ul>


### PR DESCRIPTION
Related to [SYS-1098](https://uclalibrary.atlassian.net/browse/SYS-1098).  Bumps version to `v1.1.5` for deployment.

This PR fixes a problem with the `audit_media_files` command.  Previously, it scanned all subdirectories of `MEDIA_ROOT`.  In our production environment, that is `/media`... which also has `OH_SOURCE` mounted in it as `/media/oh_source/upload`.  `/media/oh_source/` has hundreds of thousands of files which are not relevant for auditing.

`audit_media_files` now limits its scans to files in these 3 subdirectories of `MEDIA_ROOT`:
`settings.OH_MASTERS, settings.OH_STATIC, settings.OH_WOWZA`

@ztucker4 FYI, I'm merging this without review; tested locally to confirm correct behavior.


[SYS-1098]: https://uclalibrary.atlassian.net/browse/SYS-1098?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ