### PR TITLE
SYS-1098: Limit audit_media_files scan to master and derivative directories, better this time

### DIFF
--- a/charts/prod-ohstaff-values.yaml
+++ b/charts/prod-ohstaff-values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: uclalibrary/oral-history-staff-ui
-  tag: v1.1.5
+  tag: v1.1.5a
   pullPolicy: Always
 
 nameOverride: ""


### PR DESCRIPTION
The `.snapshot` subdirectories created by our backup system also need to be excluded.  This PR adds a helper generator function to obtain the items in a directory tree, with the ability to exclude a list of subdirectories (currently, `oh_source` and `.snapshot`).

Tested locally by adding several unwanted subdirectories containing thousands of files.  Confirmed these subdirectories are skipped, with no noticeable impact on performance.

@ztucker4 FYI, merging this directly.