### PR TITLE
Security fixes

### DIFF
--- a/charts/prod-ohstaff-values.yaml
+++ b/charts/prod-ohstaff-values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: uclalibrary/oral-history-staff-ui
-  tag: v1.1.6
+  tag: v1.1.7
   pullPolicy: Always
 
 nameOverride: ""

--- a/oh_staff_ui/templates/oh_staff_ui/release_notes.html
+++ b/oh_staff_ui/templates/oh_staff_ui/release_notes.html
@@ -4,6 +4,15 @@
 <h3>Release Notes</h3>
 <hr/>
 
+<h4>1.1.7</h4>
+<p><i>May 28, 2024</i></p>
+<ul>
+   <li>Fixed bug allowing staff with lower permissions to delete files if internal URLs were known.</li>
+   <li>Fixed bug allowing download of master files by anonymous users if URLs were known.</li>
+   <li>Updated gunicorn, pillow, and requests packages to patch security issues.</li>
+   <li>Fixed issue where PDF/XML submaster files displayed before master files in "File Information" table.</li>
+</ul>
+
 <h4>1.1.6</h4>
 <p><i>May 22, 2024</i></p>
 <ul>

--- a/oh_staff_ui/tests.py
+++ b/oh_staff_ui/tests.py
@@ -8,7 +8,7 @@ from django.core.files import File
 from django.core.management.base import CommandError
 from django.db import IntegrityError
 from django.http import HttpRequest
-from django.test import SimpleTestCase, TestCase, override_settings, Client
+from django.test import SimpleTestCase, TestCase, override_settings
 from django.contrib.auth.models import User, Group
 from eulxml.xmlmap import load_xmlobject_from_string, mods
 from oh_staff_ui.classes.GeneralFileHandler import GeneralFileHandler
@@ -88,9 +88,6 @@ class MediaFileTestCase(TestCase):
         # Get mock request with generic user info for command-line processing.
         cls.mock_request = HttpRequest()
         cls.mock_request.user = User.objects.get(username=cls.user.username)
-        # Add a Django client for testing web requests for media files.
-        cls.client = Client()
-        cls.client.force_login(user=cls.user)
 
     def get_full_path(self, relative_path: str) -> Path:
         # MediaFile.file.name contains a path relative to MEDIA_ROOT;
@@ -711,6 +708,7 @@ class MediaFileTestCase(TestCase):
         handler = GeneralFileHandler(master)
         handler.process_files()
         url = master.media_file.file_url
+        self.client.force_login(self.user)
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
 

--- a/oh_staff_ui/urls.py
+++ b/oh_staff_ui/urls.py
@@ -1,5 +1,3 @@
-from django.conf import settings
-from django.views.static import serve
 from django.urls import path, re_path
 from . import views
 
@@ -20,8 +18,8 @@ urlpatterns = [
     path("delete_file/<int:file_id>", views.delete_file, name="delete_file"),
     path("order_files/<int:item_id>", views.order_files, name="order_files"),
     path("browse/", views.browse, name="browse"),
-    # Allow access to download media files via built-in view django.views.static.serve()
-    re_path(r"^media/(?P<path>.*)$", serve, {"document_root": settings.MEDIA_ROOT}),
+    # Allow staff access to download media files
+    re_path(r"^media/(?P<path>.*)$", views.serve_media_file, name="serve_media_file"),
     # To follow OAI practice, a query parameter combination is requred of either:
     # verb=GetRecord and identifier={ark_value}
     # verb=ListRecords

--- a/oh_staff_ui/views.py
+++ b/oh_staff_ui/views.py
@@ -1,6 +1,7 @@
 import logging
 from threading import Thread
 from requests.exceptions import HTTPError
+from django.conf import settings
 from django.contrib import messages
 from django.core.exceptions import PermissionDenied
 from django.core.management.base import CommandError
@@ -8,6 +9,7 @@ from django.shortcuts import redirect, render
 from django.contrib.auth.decorators import login_required
 from django.http.request import HttpRequest  # for code completion
 from django.http.response import HttpResponse  # for code completion
+from django.views.static import serve
 from oh_staff_ui.forms import (
     FileUploadForm,
     ProjectItemForm,
@@ -205,6 +207,16 @@ def delete_file(request: HttpRequest, file_id: int) -> HttpResponse:
             f"Unauthorized attempt to delete {media_file.file} ({file_id}) by {request.user}"
         )
         raise PermissionDenied
+
+
+@login_required
+def serve_media_file(request: HttpRequest, path: str) -> HttpResponse:
+    # Wrap django.views.static.serve view, which normally is in urls.py,
+    # so that login requirement is enforced.
+    # The path parameter comes from re_path in urls.py.
+    # django.views.static.serve is a view, so returns HttpResponse already;
+    # we just pass it on.
+    return serve(request, path=path, document_root=settings.MEDIA_ROOT)
 
 
 @login_required

--- a/oh_staff_ui/views.py
+++ b/oh_staff_ui/views.py
@@ -137,8 +137,10 @@ def show_log(request, line_count: int = 200) -> HttpResponse:
 @login_required
 def upload_file(request: HttpRequest, item_id: int) -> HttpResponse:
     item = ProjectItem.objects.get(pk=item_id)
+    # Sort for display: file_code works for images & audio, file(name)
+    # breaks the tie for pdf & text, since oh_masters -> oh_submasters.
     files = MediaFile.objects.filter(item=item).order_by(
-        "sequence", "file_type__file_code"
+        "sequence", "file_type__file_code", "file"
     )
     # add "children" attribute to each file to hold its derivatives
     # this is used in the template to display child files before deletion

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 Django == 4.2.11
 psycopg2 == 2.9.5
-gunicorn == 20.1.0
+gunicorn == 22.0.0
 whitenoise == 6.0.0
-requests == 2.31.0
-pillow == 10.2.0
+requests == 2.32.2
+pillow == 10.3.0
 ffmpeg-python == 0.2.0
 eulxml == 1.1.3
 ply == 3.11


### PR DESCRIPTION
Implements [SYS-1612](https://uclalibrary.atlassian.net/browse/SYS-1612) and [SYS-1621](https://uclalibrary.atlassian.net/browse/SYS-1621), with other minor changes.  Tagged as version `v1.1.7` for deployment.

This PR primarily fixes two bugs:
1. Prevents master file downloads by anonymous users.  The generic static `serve` view used with `media/` paths is now wrapped by a custom `serve_media_files` view, which requires login.  Otherwise, anyone who could figure out a URL for a master file could download it from anywhere.  There also are tests covering this now.
2. Enforces correct authorization for the `delete_file` view. The check for group membership has been added to the view itself, and a `PermissionDenied` exception is raised with HTTP 403 (and message logged) if violated.  This protects against the unlikely, but possible, case where a valid but unauthorized user could figure out the URL to delete a file via the view, and called that URL directly.

Other minor changes:
* Updated various packages for security fixes
* Refactored some tests to remove duplicate code, fixed some copy/paste code, and simplify use of Django's test client for web requests
* Tweaked sorting of files in `upload_file` to include file name as tertiary sort, after sequence and file code.  This fixes a (visual) problem where submasters for PDF/XML files could be listed before masters, since there's no special submaster file codes for those.

### Testing
(Re)start system to pick up changes from `requirements.txt`.
There are 107 tests, all should pass.

For extra manual testing / confirmation
* File deletion 
  * Log in as a user not in the "Oral History Staff" group (or temporarily remove it from your user).
  * Find a `MediaFile.id`, then go to http://127.0.0.1:8000/delete_file/that_id .
  * You should get a "403 Forbidden" page (and the file should not get deleted).  The logs should show a `PermissionDenied` exception, along with something like
`WARNING 2024-05-24 12:16:16,204 oh_staff_ui.views views Unauthorized attempt to delete oh_static/pdf/submasters/fake-ce54fea54d-2-submaster.pdf (25475) by akohler`
* Master file access 
  * Find the URL for a valid master file you've ingested locally, preferably one you can view via browser like PDF or XML.
  * Confirm you can view it via browser, when logged in to the application.
  * Try to retrieve it from outside the application, either another browser (not logged in) or via curl.
  * Anonymous browser: should redirect to the login screen
  * curl: should give you a 302 response, showing `Location` redirect to the login screen
```
$ curl -I http://127.0.0.1:8000/media/oh_masters/pdf/masters/fake-ce54fea54d-2-master.pdf
HTTP/1.1 302 Found
Date: Fri, 24 May 2024 19:19:27 GMT
Server: WSGIServer/0.2 CPython/3.11.5
Content-Type: text/html; charset=utf-8
Location: /accounts/login/?next=/media/oh_masters/pdf/masters/fake-ce54fea54d-2-master.pdf
X-Frame-Options: DENY
Vary: Cookie
X-Content-Type-Options: nosniff
Referrer-Policy: same-origin
Cross-Origin-Opener-Policy: same-origin
```


[SYS-1612]: https://uclalibrary.atlassian.net/browse/SYS-1612?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SYS-1621]: https://uclalibrary.atlassian.net/browse/SYS-1621?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ