### PR TITLE
SYS-1600: allow deletion of item records

### DIFF
--- a/charts/prod-ohstaff-values.yaml
+++ b/charts/prod-ohstaff-values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: uclalibrary/oral-history-staff-ui
-  tag: v1.1.7
+  tag: v1.1.8
   pullPolicy: Always
 
 nameOverride: ""

--- a/oh_staff_ui/templates/oh_staff_ui/edit_item.html
+++ b/oh_staff_ui/templates/oh_staff_ui/edit_item.html
@@ -293,7 +293,7 @@
     {% bootstrap_button button_type="submit" content="Save" %}
 </form>
 
-<div class = "confirm-delete-popup" id="confirm-delete-popup">
+<div class="confirm-delete-popup" id="confirm-delete-popup">
     <h3>Delete Item</h3>
     {% if children_blocking_delete or media_files_blocking_delete %}
     <p>This item has dependencies and cannot be deleted.</p>

--- a/oh_staff_ui/templates/oh_staff_ui/edit_item.html
+++ b/oh_staff_ui/templates/oh_staff_ui/edit_item.html
@@ -313,10 +313,10 @@
         {% endfor %}
     </ul>
     {% endif %}
-    <a href="#" class="btn btn-primary" id="cancel-item" onclick="hideItemConfirmDeletePopup()">OK</a>
+    <a href="#" class="btn btn-primary" id="cancel" onclick="hideItemConfirmDeletePopup()">OK</a>
     {% else %}
     <p>Are you sure you want to delete this item: {{item.title}}?</p>
-    <a href="#" class="btn btn-primary" id="cancel-item" onclick="hideItemConfirmDeletePopup()">Cancel</a>
+    <a href="#" class="btn btn-primary" id="cancel" onclick="hideItemConfirmDeletePopup()">Cancel</a>
     <a href="{% url 'delete_item' item.id %}" class="btn btn-secondary">Delete</a> 
     {% endif %}
   </div>

--- a/oh_staff_ui/templates/oh_staff_ui/edit_item.html
+++ b/oh_staff_ui/templates/oh_staff_ui/edit_item.html
@@ -50,6 +50,9 @@
             {% if public_site_url %}
                 | <a href="{{public_site_url}}">View on public site</a>
             {% endif %}
+            {% if staff_status %}
+                | <a href="#" onclick="showItemConfirmDeletePopup()">Delete item</a>
+            {% endif %}
         </td>
     </tr>
 </table>
@@ -289,5 +292,34 @@
     <br>
     {% bootstrap_button button_type="submit" content="Save" %}
 </form>
+
+<div class = "confirm-delete-popup" id="confirm-delete-popup">
+    <h3>Delete Item</h3>
+    {% if children_blocking_delete or media_files_blocking_delete %}
+    <p>This item has dependencies and cannot be deleted.</p>
+    {% if children_blocking_delete %}
+    <p>These child items must be deleted first:</p>
+    <ul>
+        {% for child in children_blocking_delete %}
+        <li>{{ child.title }}</li>
+        {% endfor %}
+    </ul>
+    {% endif %}
+    {% if media_files_blocking_delete %}
+    <p>These media files must be deleted first:</p>
+    <ul>
+        {% for media_file in media_files_blocking_delete %}
+        <li>{{ media_file.file_name_only }}</li>
+        {% endfor %}
+    </ul>
+    {% endif %}
+    <a href="#" class="btn btn-primary" id="cancel-item" onclick="hideItemConfirmDeletePopup()">OK</a>
+    {% else %}
+    <p>Are you sure you want to delete this item: {{item.title}}?</p>
+    <a href="#" class="btn btn-primary" id="cancel-item" onclick="hideItemConfirmDeletePopup()">Cancel</a>
+    <a href="{% url 'delete_item' item.id %}" class="btn btn-secondary">Delete</a> 
+    {% endif %}
+  </div>
+
 {% endblock %}
 

--- a/oh_staff_ui/templates/oh_staff_ui/release_notes.html
+++ b/oh_staff_ui/templates/oh_staff_ui/release_notes.html
@@ -3,6 +3,11 @@
 {% block content %}
 <h3>Release Notes</h3>
 <hr/>
+<h4>1.1.8</h4>
+<p><i>May 29, 2024</i></p>
+<ul>
+   <li>Added ability to delete item records.</li>
+</ul>
 
 <h4>1.1.7</h4>
 <p><i>May 28, 2024</i></p>

--- a/oh_staff_ui/templates/oh_staff_ui/upload_file.html
+++ b/oh_staff_ui/templates/oh_staff_ui/upload_file.html
@@ -62,7 +62,7 @@
       {% endfor %}
     </ul>
     {% endif %}
-    <a href="#" class="btn btn-primary" id="cancel-{{file.id}}" onclick="hideConfirmDeletePopup('{{file.id}}')">Cancel</a>
+    <a href="#" class="btn btn-primary" id="cancel-{{file.id}}" onclick="hideFileConfirmDeletePopup('{{file.id}}')">Cancel</a>
     <a href="{% url 'delete_file' file.id %}" class="btn btn-secondary">Delete</a> 
   </div>
   <tr>
@@ -80,7 +80,7 @@
     <td>{{ file.sequence }}</td>
     {% if staff_status %}  
     <td>
-      <button class="delete-link btn btn-primary" onclick="showConfirmDeletePopup('{{ file.id }}')">Delete</button>
+      <button class="delete-link btn btn-primary" onclick="showFileConfirmDeletePopup('{{ file.id }}')">Delete</button>
     </td>
     {% endif %}
   </tr>

--- a/oh_staff_ui/urls.py
+++ b/oh_staff_ui/urls.py
@@ -5,6 +5,7 @@ urlpatterns = [
     path("add_item/", views.add_item, name="add_item"),
     path("add_item/<int:parent_id>", views.add_item, name="add_item_from_parent"),
     path("item/<int:item_id>", views.edit_item, name="edit_item"),
+    path("delete_item/<int:item_id>", views.delete_item, name="delete_item"),
     path("", views.item_search),
     path("item_search/", views.item_search, name="item_search"),
     path(

--- a/oh_staff_ui/views.py
+++ b/oh_staff_ui/views.py
@@ -7,6 +7,7 @@ from django.core.exceptions import PermissionDenied
 from django.core.management.base import CommandError
 from django.shortcuts import redirect, render
 from django.contrib.auth.decorators import login_required
+from django.views.decorators.cache import never_cache
 from django.http.request import HttpRequest  # for code completion
 from django.http.response import HttpResponse  # for code completion
 from django.views.static import serve
@@ -88,6 +89,7 @@ def add_item(request: HttpRequest, parent_id: int | None = None) -> HttpResponse
 
 
 @login_required
+@never_cache
 def edit_item(request: HttpRequest, item_id: int) -> HttpResponse:
     if request.method == "POST":
         save_all_item_data(item_id, request)

--- a/oh_staff_ui/views_utils.py
+++ b/oh_staff_ui/views_utils.py
@@ -162,7 +162,7 @@ def get_ark() -> str:
             raise
 
 
-def get_edit_item_context(item_id: int) -> dict:
+def get_edit_item_context(item_id: int, user: User) -> dict:
     # Populate forms with data from database
     item = ProjectItem.objects.get(pk=item_id)
     # item_form is "bound" with this data
@@ -203,6 +203,12 @@ def get_edit_item_context(item_id: int) -> dict:
         item_id, SubjectUsageForm, ItemSubjectUsage, "subjects"
     )
     relatives = get_relatives(item)
+    # for use in the template to display delete button if needed,
+    # determine if user is in the OH Staff group
+    staff_status = user_in_oh_staff_group(user)
+    # for use in the template to prevent deletion if item has children
+    # or associated MediaFiles, get these dependencies
+    children, media_files = get_item_dependencies(item)
     return {
         "item": item,
         "item_form": item_form,
@@ -219,6 +225,9 @@ def get_edit_item_context(item_id: int) -> dict:
         "subject_formset": subject_formset,
         "relatives": relatives,
         "public_site_url": get_public_site_url(item),
+        "staff_status": staff_status,
+        "children_blocking_delete": children,
+        "media_files_blocking_delete": media_files,
     }
 
 
@@ -639,3 +648,32 @@ def delete_file(media_file: MediaFile, user: User) -> None:
         )
     logger.info(f"File {file_name} deleted by user {user}.")
     media_file.delete()
+
+
+def delete_projectitem(project_item: ProjectItem, user: User) -> None:
+    # first check if item has child ProjectItems and block deletion if so
+    children = ProjectItem.objects.filter(parent=project_item)
+    if children:
+        logger.error(
+            f"Item {project_item.title} has child items and cannot be deleted."
+        )
+        return
+    # then check if there are any MediaFiles associated with the item
+    # if so, block deletion
+    media_files = MediaFile.objects.filter(item=project_item)
+    if media_files:
+        logger.error(
+            f"Item {project_item.title} has associated MediaFiles and cannot be deleted."
+        )
+        return
+    # finally, delete the item
+    logger.info(f"Item {project_item.title} deleted by user {user}.")
+    project_item.delete()
+
+
+def get_item_dependencies(item: ProjectItem) -> tuple:
+    # to check if we can delete an item, we need to check for both
+    # child ProjectItems and associated MediaFiles
+    children = ProjectItem.objects.filter(parent=item)
+    media_files = MediaFile.objects.filter(item=item)
+    return children, media_files

--- a/oh_staff_ui/views_utils.py
+++ b/oh_staff_ui/views_utils.py
@@ -651,16 +651,13 @@ def delete_file(media_file: MediaFile, user: User) -> None:
 
 
 def delete_projectitem(project_item: ProjectItem, user: User) -> None:
-    # first check if item has child ProjectItems and block deletion if so
-    children = ProjectItem.objects.filter(parent=project_item)
+    # check if item has child ProjectItems or MediaFiles, and block deletion if so
+    children, media_files = get_item_dependencies(project_item)
     if children:
         logger.error(
             f"Item {project_item.title} has child items and cannot be deleted."
         )
         return
-    # then check if there are any MediaFiles associated with the item
-    # if so, block deletion
-    media_files = MediaFile.objects.filter(item=project_item)
     if media_files:
         logger.error(
             f"Item {project_item.title} has associated MediaFiles and cannot be deleted."

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -103,14 +103,24 @@ if (window.location.href.endsWith("add_item/")) {
   }
 }
 
-function showConfirmDeletePopup(fileID) {
+function showFileConfirmDeletePopup(fileID) {
   fullID = "confirm-delete-popup-" + fileID;
   document.getElementById(fullID).style.display = "block";
   // set focus to "Cancel" button
   document.getElementById("cancel-" + fileID).focus();
 }
 
-function hideConfirmDeletePopup(fileID) {
+function hideFileConfirmDeletePopup(fileID) {
   fullID = "confirm-delete-popup-" + fileID;
   document.getElementById(fullID).style.display = "none";
+}
+
+function showItemConfirmDeletePopup() {
+  document.getElementById("confirm-delete-popup").style.display = "block";
+  // set focus to "Cancel" button
+  document.getElementById("cancel").focus();
+}
+
+function hideItemConfirmDeletePopup() {
+  document.getElementById("confirm-delete-popup").style.display = "none";
 }


### PR DESCRIPTION
Implements [SYS-1600](https://uclalibrary.atlassian.net/browse/SYS-1600)

Adds the ability to delete ProjectItems without dependencies for users in the OH Staff user group. Users in this group will see a "Delete item" link within the "Item Actions" area of `edit_item` pages. Clicking this link will bring up a "Delete Item" modal. If the item has child ProjectItems or associated MediaFiles, the modal informs the user of these dependencies and the user has no option to delete. If the item can be deleted, the user is given the choice to "Delete" or "Cancel", with "Cancel" as the default. After deletion, if the item had a parent, the user is redirected to the parent's `edit_item` page. If not, the user is redirected to `item_search`. 

The underlying deletion view (`delete_item`) enforces that the requesting user must be in the OH Staff group, and that the item actually has no dependencies. In any case, a message is logged (indicating if an item was not deleted due to dependencies, if an unauthorized user attempts to use the deletion view directly, or if an item is deleted successfully). 

Also includes minor refactoring of the unrelated `upload_file` template to use better function names to control confirmation modals, four new tests (111 total), release notes and tag bump for deployment.



[SYS-1600]: https://uclalibrary.atlassian.net/browse/SYS-1600?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ