### PR TITLE
SYS-1609: Improve logging for file creation failures

### DIFF
--- a/.docker-compose_django.env
+++ b/.docker-compose_django.env
@@ -35,7 +35,7 @@ DJANGO_OH_FILE_SOURCE=samples
 #DJANGO_OH_FILE_SOURCE=/home/django/oral-history-staff-ui/samples
 
 # Where Django looks for uploaded files
-DJANGO_OH_MEDIA_ROOT=/tmp/media_dev
+DJANGO_OH_MEDIA_ROOT=secret_media
 # Relative paths within oh_media_root, used by Django
 # Master files
 DJANGO_OH_MASTERS=oh_masters

--- a/charts/prod-ohstaff-values.yaml
+++ b/charts/prod-ohstaff-values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: uclalibrary/oral-history-staff-ui
-  tag: v1.1.8
+  tag: v1.1.9
   pullPolicy: Always
 
 nameOverride: ""

--- a/oh_staff_ui/classes/AudioFileHandler.py
+++ b/oh_staff_ui/classes/AudioFileHandler.py
@@ -78,8 +78,10 @@ class AudioFileHandler(BaseFileHandler):
             # Before processing, check to see if item already has files,
             # and reject this new file if it does.
             if self._item_has_files():
-                error_message = f"Error: Cannot add {self._master_file.file_name}; "
-                "this item already has files."
+                error_message = (
+                    f"Error: Cannot add {self._master_file.file_name}; "
+                    f"this item already has files."
+                )
                 # Capture error to database for display in template as well.
                 MediaFileError.objects.create(
                     file_name=self._master_file.file_name,

--- a/oh_staff_ui/classes/OralHistoryFile.py
+++ b/oh_staff_ui/classes/OralHistoryFile.py
@@ -1,10 +1,13 @@
 # Utility functions for file handling.
+import logging
 from pathlib import Path
 from django.conf import settings
 from django.core.files import File
 from django.db.models import Max
 from django.http import HttpRequest
-from oh_staff_ui.models import MediaFile, MediaFileType, ProjectItem
+from oh_staff_ui.models import MediaFile, MediaFileError, MediaFileType, ProjectItem
+
+logger = logging.getLogger(__name__)
 
 
 class OralHistoryFile:
@@ -71,7 +74,6 @@ class OralHistoryFile:
         new_file_name = self.get_new_file_name(next_sequence)
         # Combine filename with directory to get full path for MediaFile creation.
         new_name = f"{self._target_dir}/{new_file_name}"
-
         new_file = MediaFile(
             created_by=self._request.user,
             item=self._item,
@@ -80,15 +82,34 @@ class OralHistoryFile:
             sequence=next_sequence,
             parent_id=parent_id,
         )
+
         # Read the original file, copying it to new_name and saving the MediaFile.
-        # Get original filesize first, since it's not available in the context below.
-        file_size = self._file_size
         with Path(self._original_file_name).open(mode="rb") as f:
             new_file.file = File(f, name=new_name)
-            new_file.file_size = file_size
+            # Use original file size, since it's not available in this context.
+            new_file.file_size = self._file_size
             new_file.save()
             # Also store it for read-only access by callers.
             self._media_file = new_file
+
+        # Apparently, creating a MediaFile can silently fail, at least for audio files.
+        # Not sure how best to handle this; for now, check to see if the new file was
+        # created by Django.
+        new_disk_file = Path(settings.MEDIA_ROOT).joinpath(new_file.file.name)
+        if not new_disk_file.exists():
+            # Capture error to database for display in template as well.
+            # Since we don't know what went wrong, dump new_file via vars().
+            error_message = (
+                f"Unable to create MediaFile for an unknown reason - contact DIIT."
+                f"{vars(new_file)}"
+            )
+            MediaFileError.objects.create(
+                file_name=self.file_name,
+                item=self.item,
+                message=error_message,
+            )
+            # ValueError seems to fit best here for now, and is handled by callers.
+            raise ValueError(error_message)
 
     def get_content_type(self, file_name: str) -> str:
         """Get broad type of content based on file extension.

--- a/oh_staff_ui/templates/oh_staff_ui/release_notes.html
+++ b/oh_staff_ui/templates/oh_staff_ui/release_notes.html
@@ -3,6 +3,12 @@
 {% block content %}
 <h3>Release Notes</h3>
 <hr/>
+<h4>1.1.9</h4>
+<p><i>June 5, 2024</i></p>
+<ul>
+   <li>Added code to capture more information if file creation unexpectedly fails.</li>
+</ul>
+
 <h4>1.1.8</h4>
 <p><i>May 29, 2024</i></p>
 <ul>


### PR DESCRIPTION
Implements [SYS-1609](https://uclalibrary.atlassian.net/browse/SYS-1609).  Bumps version to `v1.1.9` for deployment.

This PR improves handling of `MediaFile` creation, which all happens via `OralHistoryFile.process_media_files()`.  `MediaFile` creation now is wrapped in a `try` block which catches generic `OSError`s. This should handle errors with permissions, non-existent directories which can't be created by Django, and full disks.  These are now caught, logged, stored in the database as `MediaFileError`s to display in the UI, and then re-raised as `ValueError` to be handled gracefully by the UI.

It also fixes a small bug in `AudioFileHandler` where what should have been a multi-line string was actually two strings, so the second one was ignored.

Finally, it changes `MEDIA_ROOT` in the developer environment to `secret_media`, which is inside the volume mounted by Docker, instead of `/tmp/media_dev` which is not.  This makes it easy to interact with uploaded files from the developer's host system, instead of having to `docker cp` or shell into the container.

### Testing

I tried for hours to write a working test which covered this, but ultimately gave up.  I simulated `MEDIA_ROOT` being a directory owned only by `root`, so Django didn't have permissions; `MEDIA_ROOT` being full, by pointing it to `/dev/full` - but that's a file, not a directory, so didn't work as expected; and removing write permissions from the target directory within `MEDIA_ROOT`.  All failed... a `PermissionError` would get raised during the test, but could not be caught/handled via `assertRaises`, and then the failure would cascade to other tests.

However, testing manually works.  I manually changed permissions on a target directory, removing write permissions:
`chmod u-w secret_media/oh_masters/text/masters`

Then upload a text (XML) file to an item.  You should get a display like this:
![oh_upload_failure](https://github.com/UCLALibrary/oral-history-staff-ui/assets/2213836/6437bc07-06c0-4b69-8ea1-27ee8d48afc8)

Then change permissions back to normal, and file upload should work now:
`chmod u+w secret_media/oh_masters/text/masters`

Since this class of error is unlikely to really happen (permissions and directories are all controlled in the container, and a full disk is unlikely though possible), I'm not spending more time trying to get a passing test.


[SYS-1609]: https://uclalibrary.atlassian.net/browse/SYS-1609?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ