### PR TITLE
SYS-1630: fix alignment on edit_item form

### DIFF
--- a/charts/prod-ohstaff-values.yaml
+++ b/charts/prod-ohstaff-values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: uclalibrary/oral-history-staff-ui
-  tag: v1.1.9
+  tag: v1.1.10
   pullPolicy: Always
 
 nameOverride: ""

--- a/oh_staff_ui/templates/oh_staff_ui/edit_item.html
+++ b/oh_staff_ui/templates/oh_staff_ui/edit_item.html
@@ -100,7 +100,7 @@
             </td>
             <td class="qualifier">{% bootstrap_field name_form.usage_id %} {% bootstrap_field name_form.type show_label=False %}</td>
             <td>{% bootstrap_field name_form.value show_label=False %}</td>
-            <td>{% bootstrap_field name_form.DELETE %}</td>
+            <td class="form-checkbox">{% bootstrap_field name_form.DELETE %}</td>
         </tr>
         {% endfor %}
         <tr id="name_empty_form" class="empty_form">
@@ -108,7 +108,7 @@
             <td class="qualifier">{% bootstrap_field name_formset.empty_form.usage_id %} 
                 {% bootstrap_field name_formset.empty_form.type show_label=False %}</td>
             <td>{% bootstrap_field name_formset.empty_form.value show_label=False %}</td>
-            <td>{% bootstrap_field name_formset.empty_form.DELETE %}</td>
+            <td class="form-checkbox">{% bootstrap_field name_formset.empty_form.DELETE %}</td>
         </tr>
         {% for subject_form in subject_formset %}
         <tr>
@@ -118,7 +118,7 @@
             </td>
             <td class="qualifier">{% bootstrap_field subject_form.usage_id %} {% bootstrap_field subject_form.type show_label=False %}</td>
             <td>{% bootstrap_field subject_form.value show_label=False %}</td>
-            <td>{% bootstrap_field subject_form.DELETE %}</td>
+            <td class="form-checkbox">{% bootstrap_field subject_form.DELETE %}</td>
         </tr>
         {% endfor %}
         <tr id="subject_empty_form" class="empty_form">
@@ -126,7 +126,7 @@
             <td class="qualifier">{% bootstrap_field subject_formset.empty_form.usage_id %} 
                 {% bootstrap_field subject_formset.empty_form.type show_label=False %}</td>
             <td>{% bootstrap_field subject_formset.empty_form.value show_label=False %}</td>
-            <td>{% bootstrap_field subject_formset.empty_form.DELETE %}</td>
+            <td class="form-checkbox">{% bootstrap_field subject_formset.empty_form.DELETE %}</td>
         </tr>
         {% for publisher_form in publisher_formset %}
         <tr>
@@ -136,7 +136,7 @@
             </td>
             <td class="qualifier">{% bootstrap_field publisher_form.usage_id %} {% bootstrap_field publisher_form.type show_label=False %}</td>
             <td>{% bootstrap_field publisher_form.value show_label=False %}</td>
-            <td>{% bootstrap_field publisher_form.DELETE %}</td>
+            <td class="form-checkbox">{% bootstrap_field publisher_form.DELETE %}</td>
         </tr>
         {% endfor %}
         <tr id="publisher_empty_form" class="empty_form">
@@ -144,7 +144,7 @@
             <td class="qualifier">{% bootstrap_field publisher_formset.empty_form.usage_id %} 
                 {% bootstrap_field publisher_formset.empty_form.type show_label=False %}</td>
             <td>{% bootstrap_field publisher_formset.empty_form.value show_label=False %}</td>
-            <td>{% bootstrap_field publisher_formset.empty_form.DELETE %}</td>
+            <td class="form-checkbox">{% bootstrap_field publisher_formset.empty_form.DELETE %}</td>
         </tr>
         {% for copyright_form in copyright_formset %}
         <tr>
@@ -154,7 +154,7 @@
             </td>
             <td class="qualifier">{% bootstrap_field copyright_form.usage_id %} {% bootstrap_field copyright_form.type show_label=False %}</td>
             <td>{% bootstrap_field copyright_form.value show_label=False %}</td>
-            <td>{% bootstrap_field copyright_form.DELETE %}</td>
+            <td class="form-checkbox">{% bootstrap_field copyright_form.DELETE %}</td>
         </tr>
         {% endfor %}
         <tr id="copyright_empty_form" class="empty_form">
@@ -162,7 +162,7 @@
             <td class="qualifier">{% bootstrap_field copyright_formset.empty_form.usage_id %} 
                 {% bootstrap_field copyright_formset.empty_form.type show_label=False %}</td>
             <td>{% bootstrap_field copyright_formset.empty_form.value show_label=False %}</td>
-            <td>{% bootstrap_field copyright_formset.empty_form.DELETE %}</td>
+            <td class="form-checkbox">{% bootstrap_field copyright_formset.empty_form.DELETE %}</td>
         </tr>
         {% for resource_form in resource_formset %}
         <tr>
@@ -172,7 +172,7 @@
             </td>
             <td class="qualifier">{% bootstrap_field resource_form.usage_id %} {% bootstrap_field resource_form.type show_label=False %}</td>
             <td>{% bootstrap_field resource_form.value show_label=False %}</td>
-            <td>{% bootstrap_field resource_form.DELETE %}</td>
+            <td class="form-checkbox">{% bootstrap_field resource_form.DELETE %}</td>
         </tr>
         {% endfor %}
         <tr id="resource_empty_form" class="empty_form">
@@ -180,7 +180,7 @@
             <td class="qualifier">{% bootstrap_field resource_formset.empty_form.usage_id %} 
                 {% bootstrap_field resource_formset.empty_form.type show_label=False %}</td>
             <td>{% bootstrap_field resource_formset.empty_form.value show_label=False %}</td>
-            <td>{% bootstrap_field resource_formset.empty_form.DELETE %}</td>
+            <td class="form-checkbox">{% bootstrap_field resource_formset.empty_form.DELETE %}</td>
         </tr>
         {% for alt_title_form in alt_title_formset %}
         <tr>
@@ -190,7 +190,7 @@
             </td>
             <td class="qualifier">{% bootstrap_field alt_title_form.usage_id %} {% bootstrap_field alt_title_form.type show_label=False %}</td>
             <td>{% bootstrap_field alt_title_form.value show_label=False placeholder="" %}</td>
-            <td>{% bootstrap_field alt_title_form.DELETE %}</td>
+            <td class="form-checkbox">{% bootstrap_field alt_title_form.DELETE %}</td>
         </tr>
         {% endfor %}
         <tr id="alt_title_empty_form" class="empty_form">
@@ -198,7 +198,7 @@
             <td class="qualifier">{% bootstrap_field alt_title_formset.empty_form.usage_id %} 
                 {% bootstrap_field alt_title_formset.empty_form.type show_label=False %}</td>
             <td>{% bootstrap_field alt_title_formset.empty_form.value show_label=False placeholder="" %}</td>
-            <td>{% bootstrap_field alt_title_formset.empty_form.DELETE %}</td>
+            <td class="form-checkbox">{% bootstrap_field alt_title_formset.empty_form.DELETE %}</td>
         </tr>
         {% for alt_id_form in alt_id_formset %}
         <tr>
@@ -208,7 +208,7 @@
             </td>
             <td class="qualifier">{% bootstrap_field alt_id_form.usage_id %} {% bootstrap_field alt_id_form.type show_label=False %}</td>
             <td>{% bootstrap_field alt_id_form.value show_label=False placeholder="" %}</td>
-            <td>{% bootstrap_field alt_id_form.DELETE %}</td>
+            <td class="form-checkbox">{% bootstrap_field alt_id_form.DELETE %}</td>
         </tr>
         {% endfor %}
         <tr id="alt_id_empty_form" class="empty_form">
@@ -216,7 +216,7 @@
             <td class="qualifier">{% bootstrap_field alt_id_formset.empty_form.usage_id %} 
                 {% bootstrap_field alt_id_formset.empty_form.type show_label=False %}</td>
             <td>{% bootstrap_field alt_id_formset.empty_form.value show_label=False placeholder="" %}</td>
-            <td>{% bootstrap_field alt_id_formset.empty_form.DELETE %}</td>
+            <td class="form-checkbox">{% bootstrap_field alt_id_formset.empty_form.DELETE %}</td>
         </tr>
         {% for description_form in description_formset %}
         <tr class = "description text-nowrap">
@@ -226,7 +226,7 @@
             </td>
             <td class="qualifier">{% bootstrap_field description_form.usage_id %} {% bootstrap_field description_form.type show_label=False %}</td>
             <td>{% bootstrap_field description_form.value show_label=False placeholder="" %}</td>
-            <td>{% bootstrap_field description_form.DELETE %}</td>
+            <td class="form-checkbox">{% bootstrap_field description_form.DELETE %}</td>
         </tr>
         {% endfor %}
         <tr id="description_empty_form" class="empty_form">
@@ -234,7 +234,7 @@
             <td class="qualifier">{% bootstrap_field description_formset.empty_form.usage_id %} 
                 {% bootstrap_field description_formset.empty_form.type show_label=False %}</td>
             <td>{% bootstrap_field description_formset.empty_form.value show_label=False placeholder="" %}</td>
-            <td>{% bootstrap_field description_formset.empty_form.DELETE %}</td>
+            <td class="form-checkbox">{% bootstrap_field description_formset.empty_form.DELETE %}</td>
         </tr>
         {% for date_form in date_formset %}
         <tr>
@@ -244,7 +244,7 @@
             </td>
             <td class="qualifier">{% bootstrap_field date_form.usage_id %} {% bootstrap_field date_form.type show_label=False %}</td>
             <td>{% bootstrap_field date_form.value show_label=False placeholder="" %}</td>
-            <td>{% bootstrap_field date_form.DELETE %}</td>
+            <td class="form-checkbox">{% bootstrap_field date_form.DELETE %}</td>
         </tr>
         {% endfor %}
         <tr id="date_empty_form" class="empty_form">
@@ -252,7 +252,7 @@
             <td class="qualifier">{% bootstrap_field date_formset.empty_form.usage_id %} 
                 {% bootstrap_field date_formset.empty_form.type show_label=False %}</td>
             <td>{% bootstrap_field date_formset.empty_form.value show_label=False placeholder="" %}</td>
-            <td>{% bootstrap_field date_formset.empty_form.DELETE %}</td>
+            <td class="form-checkbox">{% bootstrap_field date_formset.empty_form.DELETE %}</td>
         </tr>
         {% for format_form in format_formset %}
         <tr>
@@ -262,14 +262,14 @@
             </td>
             <td>{% bootstrap_field format_form.usage_id %}</td>
             <td>{% bootstrap_field format_form.value show_label=False placeholder="" %}</td>
-            <td>{% bootstrap_field format_form.DELETE %}</td>
+            <td class="form-checkbox">{% bootstrap_field format_form.DELETE %}</td>
         </tr>
         {% endfor %}
         <tr id="format_empty_form" class="empty_form">
             <td></td>
             <td>{% bootstrap_field format_formset.empty_form.usage_id %}</td>
             <td>{% bootstrap_field format_formset.empty_form.value show_label=False placeholder="" %}</td>
-            <td>{% bootstrap_field format_formset.empty_form.DELETE %}</td>
+            <td class="form-checkbox">{% bootstrap_field format_formset.empty_form.DELETE %}</td>
         </tr>
         {% for language_form in language_formset %}
         <tr>
@@ -279,14 +279,14 @@
             </td>
             <td>{% bootstrap_field language_form.usage_id %}</td>
             <td>{% bootstrap_field language_form.value show_label=False %}</td>
-            <td>{% bootstrap_field language_form.DELETE %}</td>
+            <td class="form-checkbox">{% bootstrap_field language_form.DELETE %}</td>
         </tr>
         {% endfor %}
         <tr id="language_empty_form" class="empty_form">
             <td></td>
             <td>{% bootstrap_field language_formset.empty_form.usage_id %}</td>
             <td>{% bootstrap_field language_formset.empty_form.value show_label=False %}</td>
-            <td>{% bootstrap_field language_formset.empty_form.DELETE %}</td>
+            <td class="form-checkbox">{% bootstrap_field language_formset.empty_form.DELETE %}</td>
         </tr>
     </table>
     <br>

--- a/oh_staff_ui/templates/oh_staff_ui/release_notes.html
+++ b/oh_staff_ui/templates/oh_staff_ui/release_notes.html
@@ -3,6 +3,12 @@
 {% block content %}
 <h3>Release Notes</h3>
 <hr/>
+<h4>1.1.10</h4>
+<p><i>June 6, 2024</i></p>
+<ul>
+   <li>Fix alignment of item metadata form fields.</li>
+</ul>
+
 <h4>1.1.9</h4>
 <p><i>June 5, 2024</i></p>
 <ul>

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -28,9 +28,20 @@ td.search-type {
   font-weight: bold;
 }
 
+#edit_item .form-control {
+  display: inline;
+}
+
+#edit_item tr,
 td.label,
-td.qualifier {
-  vertical-align: baseline;
+td.qualifier,
+#edit_item textarea {
+  vertical-align: top;
+}
+
+td.label button,
+td.form-checkbox {
+  vertical-align: middle;
 }
 
 td.label {


### PR DESCRIPTION
Implements [SYS-1630](https://uclalibrary.atlassian.net/issues/SYS-1630)

Makes a few CSS and HTML changes to fix alignment issues in the main `edit_item` form. 

`vertical-align: baseline` is implemented differently in different browsers, so this has been removed in favor of `vertical-align: top` (for labels and form fields) and `vertical-align: middle` (for buttons and checkboxes). To support this, the class name `form-checkbox` was added to table cells containing “Delete?” checkboxes in the `edit_item` template. Some CSS was also added to override default Bootstrap behavior for form fields.

I was not able to replicate the level of misalignment shown in the screenshot on the ticket (tried in Firefox, Chrome, and Safari on Mac at various window sizes), so please take a look at a few different items to make sure this actually addresses the main issues.

[SYS-1630]: https://uclalibrary.atlassian.net/browse/SYS-1630?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ