### PR TITLE
SYS-1637: Remove master file URLs from OAI feed

### DIFF
--- a/charts/prod-ohstaff-values.yaml
+++ b/charts/prod-ohstaff-values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: uclalibrary/oral-history-staff-ui
-  tag: v1.1.10
+  tag: v1.1.11
   pullPolicy: Always
 
 nameOverride: ""

--- a/oh_staff_ui/classes/OralHistoryMods.py
+++ b/oh_staff_ui/classes/OralHistoryMods.py
@@ -179,7 +179,8 @@ class OralHistoryMods(MODSv34):
         for ts in MediaFile.objects.filter(
             item=pi, file_type__file_code="text_master_transcript"
         ):
-            if ts.file_url != "" and ts.file_url.endswith(".xml"):
+            # Add only for submasters, the public-access copy
+            if ts.file_url.endswith("submaster.xml"):
                 # Due to legacy design the text_master_transcript can have 2 file types
                 # associated with it, we only want to show xml (TEI), and ignore html files
                 ri.locations.append(LocationOH(url=ts.file_url, usage="timed log"))
@@ -208,7 +209,8 @@ class OralHistoryMods(MODSv34):
         for f in MediaFile.objects.filter(
             item=self._item, file_type__file_code__in=fc_to_label.keys()
         ).order_by("sequence"):
-            if f.file_url != "":
+            # Add only for submasters, the public-access copy
+            if "submaster" in f.file_url:
                 label = fc_to_label[f.file_type.file_code]
                 usage = ""
 
@@ -219,7 +221,8 @@ class OralHistoryMods(MODSv34):
                         label = f"{label} (TEI/P5 XML)"
                         usage = "timed log"
 
-                # If our MediaFile is TEI/P5 XML, a usage attribute is populated and should be included
+                # If our MediaFile is TEI/P5 XML, a usage attribute is populated
+                # and should be included
                 if usage:
                     self.locations.append(
                         LocationOH(url=f.file_url, label=label, usage=usage)

--- a/oh_staff_ui/templates/oh_staff_ui/release_notes.html
+++ b/oh_staff_ui/templates/oh_staff_ui/release_notes.html
@@ -3,10 +3,16 @@
 {% block content %}
 <h3>Release Notes</h3>
 <hr/>
+<h4>1.1.11</h4>
+<p><i>June 12, 2024</i></p>
+<ul>
+   <li>Fixed bug which included master file URLs in the OAI feed.</li>
+</ul>
+
 <h4>1.1.10</h4>
 <p><i>June 6, 2024</i></p>
 <ul>
-   <li>Fix alignment of item metadata form fields.</li>
+   <li>Fixed alignment of item metadata form fields.</li>
 </ul>
 
 <h4>1.1.9</h4>

--- a/oh_staff_ui/tests.py
+++ b/oh_staff_ui/tests.py
@@ -1543,6 +1543,12 @@ class ModsTestCase(TestCase):
         # That title should not be present, since that item has been Sealed.
         self.assertNotIn("Fake audio", related_titles)
 
+    def test_master_file_urls_are_excluded(self):
+        # Confirm that master file URLs, which are only used in the staff UI,
+        # are not included in the OAI feed.
+        ohmods = self.get_mods_from_interview_item()
+        self.assertFalse(b"/oh_masters/" in ohmods.serializeDocument())
+
 
 class FileMetadataMigrationTestCase(SimpleTestCase):
     # Test logic not already covered by OralHistoryFile tests.


### PR DESCRIPTION
Implements [SYS-1637](https://uclalibrary.atlassian.net/browse/SYS-1637).  Bumps version to `v1.1.11` for deployment.

This PR fixes a bug which allowed URLs for master files to be included in the OAI feed.  These files are accessible only via the staff UI, so including URLs for them is not appropriate for OAI content or the public site.

The fix makes relevant methods in the `OralHistoryMods` class more specific, so only file URLs for submasters are included in the OAI feed's MODs records.  A new test is added which confirms master file URLs are not included.

### Testing

Confirm all 112 tests pass.  No need for more specific testing.

Locally, I grabbed before and after versions of 2 records and compared them:
```
$ diff zz002kppdz_before.xml zz002kppdz_after.xml
3c3
<   <responseDate>2024-06-12T12:34:03Z</responseDate>
---
>   <responseDate>2024-06-12T12:49:14Z</responseDate>
67,69d66
<               <mods:url usage="timed log">/media/oh_masters/text/masters/21198-zz002kppg0-3-master.xml</mods:url>
<             </mods:location>
<             <mods:location>
72,74d68
<             <mods:location>
<               <mods:url usage="timed log">/media/oh_masters/text/masters/21198-zz002kppg0-4-master.xml</mods:url>
<             </mods:location>
84,86d77
<               <mods:url usage="timed log">/media/oh_masters/text/masters/21198-zz002kpphh-2-master.xml</mods:url>
<             </mods:location>
<             <mods:location>
98,100d88
<               <mods:url usage="timed log">/media/oh_masters/text/masters/21198-zz002kppj1-2-master.xml</mods:url>
<             </mods:location>
<             <mods:location>
114,116d101
<             <mods:location>
<               <mods:url usage="timed log">/media/oh_masters/text/masters/21198-zz002kppkj-2-master.xml</mods:url>
<             </mods:location>
129,131d113
<           </mods:location>
<           <mods:location displayLabel="Interview Full Transcript (PDF)">
<             <mods:url>/media/oh_masters/pdf/masters/21198-zz002kppdz-3-master.pdf</mods:url>
```

```
$ diff zz002kqf5d_before.xml zz002kqf5d_after.xml
3c3
<   <responseDate>2024-06-12T12:18:33Z</responseDate>
---
>   <responseDate>2024-06-12T12:49:08Z</responseDate>
73,75d72
<           <mods:location displayLabel="Interview Full Transcript (PDF)">
<             <mods:url>/media/oh_masters/pdf/masters/21198-zz002kqf5d-1-master.pdf</mods:url>
<           </mods:location>
```

[SYS-1637]: https://uclalibrary.atlassian.net/browse/SYS-1637?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ