### PR TITLE
SYS-1632: improve searching options

### DIFF
--- a/charts/prod-ohstaff-values.yaml
+++ b/charts/prod-ohstaff-values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: uclalibrary/oral-history-staff-ui
-  tag: v1.1.11
+  tag: v1.1.12
   pullPolicy: Always
 
 nameOverride: ""

--- a/oh_staff_ui/forms.py
+++ b/oh_staff_ui/forms.py
@@ -127,7 +127,6 @@ class ItemSearchForm(forms.Form):
     # If these change, views_utils.get_search_results() must be updated too.
     search_types = [
         ("title", "Title"),
-        ("status", "Status"),
         ("keyword", "Keyword"),
         ("ark", "ARK"),
     ]
@@ -138,11 +137,11 @@ class ItemSearchForm(forms.Form):
         widget=forms.TextInput(attrs={"size": 80, "class": "char-query"}),
         label="Query",
     )
-    status_query = forms.ModelChoiceField(
+    status_filter = forms.ModelChoiceField(
         required=False,
         queryset=ItemStatus.objects.all().order_by("status"),
-        label="Query",
-        widget=forms.Select(attrs={"class": "status-query", "style": "display: none"}),
+        label="Status",
+        widget=forms.Select(attrs={"class": "status-filter"}),
     )
     item_type_filter = forms.ModelChoiceField(
         required=False,

--- a/oh_staff_ui/forms.py
+++ b/oh_staff_ui/forms.py
@@ -144,6 +144,20 @@ class ItemSearchForm(forms.Form):
         label="Query",
         widget=forms.Select(attrs={"class": "status-query", "style": "display: none"}),
     )
+    item_type_filter = forms.ModelChoiceField(
+        required=False,
+        queryset=ItemType.objects.all().order_by("type"),
+        label="Item type",
+        widget=forms.Select(attrs={"class": "item-type-filter"}),
+    )
+    media_file_type_filter = forms.ModelChoiceField(
+        required=False,
+        queryset=MediaFileType.objects.filter(file_code__contains="_master").order_by(
+            "file_type"
+        ),
+        label="Type of attached media files",
+        widget=forms.Select(attrs={"class": "media-file-type-filter"}),
+    )
 
 
 class NameUsageForm(forms.Form):

--- a/oh_staff_ui/templates/oh_staff_ui/item_search.html
+++ b/oh_staff_ui/templates/oh_staff_ui/item_search.html
@@ -4,6 +4,7 @@
 {% block content %}
 <form name="item_search" onsubmit ="return validateSearchForm()" id="item_search" method="POST">
     {% csrf_token %}
+    <p>Enter "*" to perform a wildcard search matching all items. This must be used together with a filter for item type or media file type.</p>
     <table>
         <tr>
             <td class="search-type">{% bootstrap_field form.search_type layout="floating" %}</td>
@@ -11,7 +12,21 @@
             <td>{% bootstrap_field form.char_query layout="floating" placeholder=""%}</td>
             <td>{% bootstrap_field form.status_query layout="floating"%}</td>
         </tr>
+        <tr>
+            <td>{% bootstrap_field form.item_type_filter layout="floating" %}</td>
+            <td></td>
+            <td></td>
+            <td></td>
+        </tr>
+        <tr>
+            <td>{% bootstrap_field form.media_file_type_filter layout="floating" %}</td>
+            <td></td>
+            <td></td>
+            <td></td>
+        </tr>
     </table>
+   
     {% bootstrap_button button_type="submit" content="Search" %}
+    
 </form>
 {% endblock %}

--- a/oh_staff_ui/templates/oh_staff_ui/item_search.html
+++ b/oh_staff_ui/templates/oh_staff_ui/item_search.html
@@ -4,26 +4,26 @@
 {% block content %}
 <form name="item_search" onsubmit ="return validateSearchForm()" id="item_search" method="POST">
     {% csrf_token %}
-    <p>Enter "*" to perform a wildcard search matching all items. This must be used together with a filter for item type or media file type.</p>
+    <p>Enter "*" to perform a wildcard search matching all items. This must be used together with a filter for status, item type, or media file type.</p>
     <table>
         <tr>
             <td class="search-type">{% bootstrap_field form.search_type layout="floating" %}</td>
-            <td></td>
             <td>{% bootstrap_field form.char_query layout="floating" placeholder=""%}</td>
-            <td>{% bootstrap_field form.status_query layout="floating"%}</td>
+            
+        </tr>
+        <tr>
+            <td>{% bootstrap_field form.status_filter layout="floating"%}</td>
+            <td></td>
         </tr>
         <tr>
             <td>{% bootstrap_field form.item_type_filter layout="floating" %}</td>
-            <td></td>
-            <td></td>
             <td></td>
         </tr>
         <tr>
             <td>{% bootstrap_field form.media_file_type_filter layout="floating" %}</td>
             <td></td>
-            <td></td>
-            <td></td>
         </tr>
+
     </table>
    
     {% bootstrap_button button_type="submit" content="Search" %}

--- a/oh_staff_ui/templates/oh_staff_ui/release_notes.html
+++ b/oh_staff_ui/templates/oh_staff_ui/release_notes.html
@@ -6,7 +6,7 @@
 <h4>1.1.12</h4>
 <p><i>June 17, 2024</i></p>
 <ul>
-   <li>Add search filters and wildcard search.</li>
+   <li>Added search filters and wildcard search.</li>
 </ul>
 
 <h4>1.1.11</h4>

--- a/oh_staff_ui/templates/oh_staff_ui/release_notes.html
+++ b/oh_staff_ui/templates/oh_staff_ui/release_notes.html
@@ -3,6 +3,12 @@
 {% block content %}
 <h3>Release Notes</h3>
 <hr/>
+<h4>1.1.12</h4>
+<p><i>June 17, 2024</i></p>
+<ul>
+   <li>Add search filters and wildcard search.</li>
+</ul>
+
 <h4>1.1.11</h4>
 <p><i>June 12, 2024</i></p>
 <ul>

--- a/oh_staff_ui/templates/oh_staff_ui/search_results.html
+++ b/oh_staff_ui/templates/oh_staff_ui/search_results.html
@@ -2,6 +2,7 @@
 
 {% block content %}
 {% if results %}
+Your search returned {{ results|length }} results.
 <table class="table">
     <thead>
         <tr>

--- a/oh_staff_ui/urls.py
+++ b/oh_staff_ui/urls.py
@@ -10,7 +10,7 @@ urlpatterns = [
     path("item_search/", views.item_search, name="item_search"),
     path(
         "search_results/<str:search_type>/<str:media_file_type_filter>/"
-        "<str:item_type_filter>/<str:query>",
+        "<str:item_type_filter>/<path:query>",
         views.search_results,
         name="search_results",
     ),

--- a/oh_staff_ui/urls.py
+++ b/oh_staff_ui/urls.py
@@ -9,7 +9,8 @@ urlpatterns = [
     path("", views.item_search),
     path("item_search/", views.item_search, name="item_search"),
     path(
-        "search_results/<str:search_type>/<path:query>",
+        "search_results/<str:search_type>/<str:media_file_type_filter>/"
+        "<str:item_type_filter>/<str:query>",
         views.search_results,
         name="search_results",
     ),

--- a/oh_staff_ui/urls.py
+++ b/oh_staff_ui/urls.py
@@ -9,8 +9,8 @@ urlpatterns = [
     path("", views.item_search),
     path("item_search/", views.item_search, name="item_search"),
     path(
-        "search_results/<str:search_type>/<str:media_file_type_filter>/"
-        "<str:item_type_filter>/<path:query>",
+        "search_results/<str:search_type>/<str:status_filter>/"
+        "<str:media_file_type_filter>/<str:item_type_filter>/<path:query>",
         views.search_results,
         name="search_results",
     ),

--- a/oh_staff_ui/views.py
+++ b/oh_staff_ui/views.py
@@ -111,11 +111,11 @@ def item_search(request: HttpRequest) -> HttpResponse:
             item_type_filter = form.cleaned_data["item_type_filter"]
             media_file_type_filter = form.cleaned_data["media_file_type_filter"]
             status_filter = form.cleaned_data["status_filter"]
-            if form.cleaned_data["item_type_filter"] is None:
+            if item_type_filter is None:
                 item_type_filter = "all"
-            if form.cleaned_data["media_file_type_filter"] is None:
+            if media_file_type_filter is None:
                 media_file_type_filter = "all"
-            if form.cleaned_data["status_filter"] is None:
+            if status_filter is None:
                 status_filter = "all"
 
             return redirect(

--- a/oh_staff_ui/views.py
+++ b/oh_staff_ui/views.py
@@ -106,8 +106,6 @@ def item_search(request: HttpRequest) -> HttpResponse:
                 typed_query = form.cleaned_data["status_query"]
             else:
                 typed_query = form.cleaned_data["char_query"]
-                # remove slashes from query to prevent url errors
-                typed_query = typed_query.replace("/", " ")
 
             # check for filter values, and set to known defaults if not present
             item_type_filter = form.cleaned_data["item_type_filter"]

--- a/oh_staff_ui/views.py
+++ b/oh_staff_ui/views.py
@@ -106,9 +106,22 @@ def item_search(request: HttpRequest) -> HttpResponse:
                 typed_query = form.cleaned_data["status_query"]
             else:
                 typed_query = form.cleaned_data["char_query"]
+                # remove slashes from query to prevent url errors
+                typed_query = typed_query.replace("/", " ")
+
+            # check for filter values, and set to known defaults if not present
+            item_type_filter = form.cleaned_data["item_type_filter"]
+            media_file_type_filter = form.cleaned_data["media_file_type_filter"]
+            if form.cleaned_data["item_type_filter"] is None:
+                item_type_filter = "all"
+            if form.cleaned_data["media_file_type_filter"] is None:
+                media_file_type_filter = "all"
+
             return redirect(
                 "search_results",
                 search_type=form.cleaned_data["search_type"],
+                item_type_filter=item_type_filter,
+                media_file_type_filter=media_file_type_filter,
                 query=typed_query,
             )
     else:
@@ -117,9 +130,27 @@ def item_search(request: HttpRequest) -> HttpResponse:
 
 
 @login_required
-def search_results(request: HttpRequest, search_type: str, query: str) -> HttpResponse:
-    results = get_search_results(search_type, query)
-    return render(request, "oh_staff_ui/search_results.html", {"results": results})
+def search_results(
+    request: HttpRequest,
+    search_type: str,
+    query: str,
+    item_type_filter: str = "",
+    media_file_type_filter: str = "",
+) -> HttpResponse:
+    results = get_search_results(
+        search_type, query, item_type_filter, media_file_type_filter
+    )
+    return render(
+        request,
+        "oh_staff_ui/search_results.html",
+        {
+            "results": results,
+            "query": query,
+            "search_type": search_type,
+            "item_type_filter": item_type_filter,
+            "media_file_type_filter": media_file_type_filter,
+        },
+    )
 
 
 @login_required

--- a/oh_staff_ui/views.py
+++ b/oh_staff_ui/views.py
@@ -110,16 +110,20 @@ def item_search(request: HttpRequest) -> HttpResponse:
             # check for filter values, and set to known defaults if not present
             item_type_filter = form.cleaned_data["item_type_filter"]
             media_file_type_filter = form.cleaned_data["media_file_type_filter"]
+            status_filter = form.cleaned_data["status_filter"]
             if form.cleaned_data["item_type_filter"] is None:
                 item_type_filter = "all"
             if form.cleaned_data["media_file_type_filter"] is None:
                 media_file_type_filter = "all"
+            if form.cleaned_data["status_filter"] is None:
+                status_filter = "all"
 
             return redirect(
                 "search_results",
                 search_type=form.cleaned_data["search_type"],
                 item_type_filter=item_type_filter,
                 media_file_type_filter=media_file_type_filter,
+                status_filter=status_filter,
                 query=typed_query,
             )
     else:
@@ -134,20 +138,15 @@ def search_results(
     query: str,
     item_type_filter: str = "",
     media_file_type_filter: str = "",
+    status_filter: str = "",
 ) -> HttpResponse:
     results = get_search_results(
-        search_type, query, item_type_filter, media_file_type_filter
+        search_type, query, item_type_filter, media_file_type_filter, status_filter
     )
     return render(
         request,
         "oh_staff_ui/search_results.html",
-        {
-            "results": results,
-            "query": query,
-            "search_type": search_type,
-            "item_type_filter": item_type_filter,
-            "media_file_type_filter": media_file_type_filter,
-        },
+        {"results": results},
     )
 
 

--- a/oh_staff_ui/views_utils.py
+++ b/oh_staff_ui/views_utils.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from django.conf import settings
 from django.contrib import messages
 from django.core.management import call_command
-from django.db.models import CharField, Model, Q, QuerySet
+from django.db.models import CharField, Model, Q
 from django.contrib.auth.models import User
 from django.forms import BaseFormSet, Form, formset_factory
 from django.http.request import HttpRequest  # for code completion

--- a/oh_staff_ui/views_utils.py
+++ b/oh_staff_ui/views_utils.py
@@ -117,28 +117,79 @@ def get_result_items(queryset_list: list) -> list[ProjectItem]:
     return output_projectitems_deduped
 
 
-def get_search_results(search_type: str, query: str) -> list[ProjectItem]:
+def get_search_results(
+    search_type: str, query: str, item_type_filter: str, media_file_type_filter: str
+) -> list[ProjectItem]:
     # Return a list of items matching the search.  Different searches have
     # different return types and sort orders; this unifies them for consistent
     # use in the view and template.
-    if search_type == "title":
+
+    # first, check if this is a wildcard search - if so, return all items
+    # no need to check search_type
+    if query == "*":
+        qs_results = ProjectItem.objects.all().order_by("title")
+        filtered_results = filter_non_keyword_results_queryset(
+            qs_results, item_type_filter, media_file_type_filter
+        )
+    elif search_type == "title":
         full_query = construct_keyword_query("title", query)
         qs_results = ProjectItem.objects.filter(full_query).order_by("title")
+        filtered_results = filter_non_keyword_results_queryset(
+            qs_results, item_type_filter, media_file_type_filter
+        )
     elif search_type == "ark":
         qs_results = ProjectItem.objects.filter(ark__icontains=query).order_by("ark")
+        filtered_results = filter_non_keyword_results_queryset(
+            qs_results, item_type_filter, media_file_type_filter
+        )
     elif search_type == "status":
         qs_results = ProjectItem.objects.filter(status__status=query).order_by("title")
+        filtered_results = filter_non_keyword_results_queryset(
+            qs_results, item_type_filter, media_file_type_filter
+        )
     elif search_type == "keyword":
         search_data = get_keyword_results(query)
         # This is a sorted list of ProjectItems already, so does not need conversion to list below.
         qs_results = get_result_items(search_data)
+        filtered_results = filter_keyword_results_list(
+            qs_results, item_type_filter, media_file_type_filter
+        )
+
     # Convert query results from QuerySet to list of items, if needed.
     # qs_results is already sorted as desired based on search_type.
-    if isinstance(qs_results, QuerySet):
-        results = [item for item in qs_results]
+    if isinstance(filtered_results, QuerySet):
+        results = [item for item in filtered_results]
     else:
-        results = qs_results
+        results = filtered_results
     return results
+
+
+def filter_keyword_results_list(
+    qs_results: list[ProjectItem], item_type_filter: str, media_file_type_filter: str
+) -> list[ProjectItem]:
+    if item_type_filter != "all":
+        qs_results = [item for item in qs_results if item.type.type == item_type_filter]
+    if media_file_type_filter != "all":
+        media_files = MediaFile.objects.filter(
+            file_type__file_type=media_file_type_filter
+        )
+        media_file_items = [media_file.item.id for media_file in media_files]
+        qs_results = [item for item in qs_results if item.id in media_file_items]
+    return qs_results
+
+
+def filter_non_keyword_results_queryset(
+    qs_results: QuerySet, item_type_filter: str, media_file_type_filter: str
+) -> QuerySet:
+    if item_type_filter != "all":
+        qs_results = qs_results.filter(type__type=item_type_filter)
+    if media_file_type_filter != "all":
+        media_files = MediaFile.objects.filter(
+            file_type__file_type=media_file_type_filter
+        )
+        media_file_items = [media_file.item.id for media_file in media_files]
+        qs_results = qs_results.filter(pk__in=media_file_items)
+    return qs_results
 
 
 def get_ark() -> str:

--- a/oh_staff_ui/views_utils.py
+++ b/oh_staff_ui/views_utils.py
@@ -132,80 +132,58 @@ def get_search_results(
     # no need to check search_type
     if query == "*":
         qs_results = ProjectItem.objects.all().order_by("title")
-        filtered_results = filter_non_keyword_results_queryset(
-            qs_results, item_type_filter, media_file_type_filter, status_filter
+        results_list = [item for item in qs_results]
+        filtered_results = filter_results_list(
+            results_list, item_type_filter, media_file_type_filter, status_filter
         )
+
     elif search_type == "title":
         full_query = construct_keyword_query("title", query)
         qs_results = ProjectItem.objects.filter(full_query).order_by("title")
-        filtered_results = filter_non_keyword_results_queryset(
-            qs_results, item_type_filter, media_file_type_filter, status_filter
+        results_list = [item for item in qs_results]
+        filtered_results = filter_results_list(
+            results_list, item_type_filter, media_file_type_filter, status_filter
         )
+
     elif search_type == "ark":
         qs_results = ProjectItem.objects.filter(ark__icontains=query).order_by("ark")
-        filtered_results = filter_non_keyword_results_queryset(
-            qs_results, item_type_filter, media_file_type_filter, status_filter
+        results_list = [item for item in qs_results]
+        filtered_results = filter_results_list(
+            results_list, item_type_filter, media_file_type_filter, status_filter
         )
-    elif search_type == "status":
-        qs_results = ProjectItem.objects.filter(status__status=query).order_by("title")
-        filtered_results = filter_non_keyword_results_queryset(
-            qs_results, item_type_filter, media_file_type_filter, status_filter
-        )
+
     elif search_type == "keyword":
         search_data = get_keyword_results(query)
         # This is a sorted list of ProjectItems already, so does not need conversion to list below.
-        qs_results = get_result_items(search_data)
-        filtered_results = filter_keyword_results_list(
-            qs_results, item_type_filter, media_file_type_filter, status_filter
+        results_list = get_result_items(search_data)
+        filtered_results = filter_results_list(
+            results_list, item_type_filter, media_file_type_filter, status_filter
         )
 
-    # Convert query results from QuerySet to list of items, if needed.
-    # qs_results is already sorted as desired based on search_type.
-    if isinstance(filtered_results, QuerySet):
-        results = [item for item in filtered_results]
-    else:
-        results = filtered_results
-    return results
+    return filtered_results
 
 
-def filter_keyword_results_list(
-    qs_results: list[ProjectItem],
+def filter_results_list(
+    results_list: list[ProjectItem],
     item_type_filter: str,
     media_file_type_filter: str,
     status_filter: str,
 ) -> list[ProjectItem]:
     if item_type_filter != "all":
-        qs_results = [item for item in qs_results if item.type.type == item_type_filter]
-    if media_file_type_filter != "all":
-        media_files = MediaFile.objects.filter(
-            file_type__file_type=media_file_type_filter
-        )
-        media_file_items = [media_file.item.id for media_file in media_files]
-        qs_results = [item for item in qs_results if item.id in media_file_items]
-    if status_filter != "all":
-        qs_results = [
-            item for item in qs_results if item.status.status == status_filter
+        results_list = [
+            item for item in results_list if item.type.type == item_type_filter
         ]
-    return qs_results
-
-
-def filter_non_keyword_results_queryset(
-    qs_results: QuerySet,
-    item_type_filter: str,
-    media_file_type_filter: str,
-    status_filter: str,
-) -> QuerySet:
-    if item_type_filter != "all":
-        qs_results = qs_results.filter(type__type=item_type_filter)
     if media_file_type_filter != "all":
         media_files = MediaFile.objects.filter(
             file_type__file_type=media_file_type_filter
         )
         media_file_items = [media_file.item.id for media_file in media_files]
-        qs_results = qs_results.filter(pk__in=media_file_items)
+        results_list = [item for item in results_list if item.id in media_file_items]
     if status_filter != "all":
-        qs_results = qs_results.filter(status__status=status_filter)
-    return qs_results
+        results_list = [
+            item for item in results_list if item.status.status == status_filter
+        ]
+    return results_list
 
 
 def get_ark() -> str:

--- a/oh_staff_ui/views_utils.py
+++ b/oh_staff_ui/views_utils.py
@@ -133,33 +133,24 @@ def get_search_results(
     if query == "*":
         qs_results = ProjectItem.objects.all().order_by("title")
         results_list = [item for item in qs_results]
-        filtered_results = filter_results_list(
-            results_list, item_type_filter, media_file_type_filter, status_filter
-        )
 
     elif search_type == "title":
         full_query = construct_keyword_query("title", query)
         qs_results = ProjectItem.objects.filter(full_query).order_by("title")
         results_list = [item for item in qs_results]
-        filtered_results = filter_results_list(
-            results_list, item_type_filter, media_file_type_filter, status_filter
-        )
 
     elif search_type == "ark":
         qs_results = ProjectItem.objects.filter(ark__icontains=query).order_by("ark")
         results_list = [item for item in qs_results]
-        filtered_results = filter_results_list(
-            results_list, item_type_filter, media_file_type_filter, status_filter
-        )
 
     elif search_type == "keyword":
         search_data = get_keyword_results(query)
         # This is a sorted list of ProjectItems already, so does not need conversion to list below.
         results_list = get_result_items(search_data)
-        filtered_results = filter_results_list(
-            results_list, item_type_filter, media_file_type_filter, status_filter
-        )
 
+    filtered_results = filter_results_list(
+        results_list, item_type_filter, media_file_type_filter, status_filter
+    )
     return filtered_results
 
 

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -50,46 +50,6 @@ function disable_upload_button(form) {
   btn.disabled = true;
 }
 
-if (document.getElementById("item_search")) {
-  // Hide Status field label by default since Title is default search type
-  labels = document.getElementsByTagName("label");
-  for (let i = 0; i < labels.length; i++) {
-    if (labels[i].getAttribute("for") == "id_status_query") {
-      labels[i].style.display = "none";
-    }
-  }
-
-  // Dynamically update available fields in item search form
-  document.getElementById("id_search_type").onchange = function () {
-    // for Status search, hide char query and make status visible
-    if (this.value == "status") {
-      document.getElementsByClassName("status-query")[0].style.display = "";
-      document.getElementsByClassName("char-query")[0].type = "hidden";
-      for (let i = 0; i < labels.length; i++) {
-        if (labels[i].getAttribute("for") == "id_char_query") {
-          labels[i].style.display = "none";
-        }
-        if (labels[i].getAttribute("for") == "id_status_query") {
-          labels[i].style.display = "";
-        }
-      }
-    }
-    // for all other searches, hide status and make char visible
-    else {
-      document.getElementsByClassName("status-query")[0].style.display = "none";
-      document.getElementsByClassName("char-query")[0].type = "";
-      for (let i = 0; i < labels.length; i++) {
-        if (labels[i].getAttribute("for") == "id_char_query") {
-          labels[i].style.display = "";
-        }
-        if (labels[i].getAttribute("for") == "id_status_query") {
-          labels[i].style.display = "none";
-        }
-      }
-    }
-  };
-}
-
 // styling for "add item" page
 if (window.location.href.endsWith("add_item/")) {
   // hide parent dropdown

--- a/static/js/validation.js
+++ b/static/js/validation.js
@@ -128,21 +128,15 @@ function checkDuplicateValues() {
 }
 
 function validateSearchForm() {
-  if (document.getElementById("id_search_type").value == "status") {
-    if (document.getElementById("id_status_query").value == "") {
-      alert("Please select a Status value.");
-      return false;
-    }
-  } else {
-    if (document.getElementById("id_char_query").value.trim().length === 0) {
-      alert("Please enter a search query.");
-      return false;
-    }
+  if (document.getElementById("id_char_query").value.trim().length === 0) {
+    alert("Please enter a search query.");
+    return false;
   }
   if (
     document.getElementById("id_char_query").value === "*" &&
     document.getElementById("id_item_type_filter").value === "" &&
-    document.getElementById("id_media_file_type_filter").value === ""
+    document.getElementById("id_media_file_type_filter").value === "" &&
+    document.getElementById("id_status_filter").value == ""
   ) {
     alert("To use wildcard search, please use at least one filter.");
     return false;

--- a/static/js/validation.js
+++ b/static/js/validation.js
@@ -1,104 +1,150 @@
 function validateEditItemForm() {
-    validMissing = checkMissingValues()
-    validDuplicates = checkDuplicateValues()
-    if (!(validMissing && validDuplicates)) {
-        return false
-    }
+  validMissing = checkMissingValues();
+  validDuplicates = checkDuplicateValues();
+  if (!(validMissing && validDuplicates)) {
+    return false;
+  }
 }
 
-function checkMissingValues(){
-    // all "optional" metadata other than Language and Format, which don't have types
-    const valuesToCheck = ["alt_id","alt_title","copyright","date","description","name","publisher","resource","subject"]
-    // more human-readable names, in the same order, for display
-    const formattedNames = ["Alt ID","Alt Title","Copyright","Date","Description","Name","Publisher","Resource","Subject"]
+function checkMissingValues() {
+  // all "optional" metadata other than Language and Format, which don't have types
+  const valuesToCheck = [
+    "alt_id",
+    "alt_title",
+    "copyright",
+    "date",
+    "description",
+    "name",
+    "publisher",
+    "resource",
+    "subject",
+  ];
+  // more human-readable names, in the same order, for display
+  const formattedNames = [
+    "Alt ID",
+    "Alt Title",
+    "Copyright",
+    "Date",
+    "Description",
+    "Name",
+    "Publisher",
+    "Resource",
+    "Subject",
+  ];
 
-    for (let i = 0; i < valuesToCheck.length; i++) {
-        // find the type and value inputs for each data type, ignoring hidden or "__prefix__"
-        typeQuery=`[name^=${valuesToCheck[i]}s][name$="type"]:not([name*="prefix"])`
-        valueQuery=`[name^=${valuesToCheck[i]}s][name$="value"]:not([name*="prefix"])`
-        types = document.querySelectorAll(typeQuery)
-        values = document.querySelectorAll(valueQuery)
+  for (let i = 0; i < valuesToCheck.length; i++) {
+    // find the type and value inputs for each data type, ignoring hidden or "__prefix__"
+    typeQuery = `[name^=${valuesToCheck[i]}s][name$="type"]:not([name*="prefix"])`;
+    valueQuery = `[name^=${valuesToCheck[i]}s][name$="value"]:not([name*="prefix"])`;
+    types = document.querySelectorAll(typeQuery);
+    values = document.querySelectorAll(valueQuery);
 
-        // for each type, check existence of type and value
-        // if exactly one exists, alert user of the problem and do not submit form
-        for (let j = 0; j < types.length; j++) {
-            if ((types[j].value && !values[j].value) || (values[j].value && !types[j].value)) {
-                alert(`Please enter both a qualifier and a value for ${formattedNames[i]}.`)
-                return false
-            }
-        }
+    // for each type, check existence of type and value
+    // if exactly one exists, alert user of the problem and do not submit form
+    for (let j = 0; j < types.length; j++) {
+      if (
+        (types[j].value && !values[j].value) ||
+        (values[j].value && !types[j].value)
+      ) {
+        alert(
+          `Please enter both a qualifier and a value for ${formattedNames[i]}.`
+        );
+        return false;
+      }
     }
-    return true
+  }
+  return true;
 }
 
-function checkDuplicateValues(){
-    // only fields with limited values and Types
-    const valuesToCheck = ["copyright","name","publisher","resource","subject"]
-    // more human-readable names, in the same order, for display
-    const formattedNames = ["Copyright","Name","Publisher","Resource","Subject"] 
-    for (let i = 0; i < valuesToCheck.length; i++) {
-        // find the type and value inputs for each data type, ignoring hidden or "__prefix__"
-        typeQuery=`[name^=${valuesToCheck[i]}s][name$="type"]:not([name*="prefix"])`
-        valueQuery=`[name^=${valuesToCheck[i]}s][name$="value"]:not([name*="prefix"])`
-        typesNodes = Array.from(document.querySelectorAll(typeQuery))
-        valuesNodes = Array.from(document.querySelectorAll(valueQuery))
-        // get array of values from each for easier iterating
-        types = []
-        values = []
-        for (let j = 0; j < typesNodes.length; j++) {
-            types.push(typesNodes[j].value)
-            values.push(valuesNodes[j].value)
+function checkDuplicateValues() {
+  // only fields with limited values and Types
+  const valuesToCheck = [
+    "copyright",
+    "name",
+    "publisher",
+    "resource",
+    "subject",
+  ];
+  // more human-readable names, in the same order, for display
+  const formattedNames = [
+    "Copyright",
+    "Name",
+    "Publisher",
+    "Resource",
+    "Subject",
+  ];
+  for (let i = 0; i < valuesToCheck.length; i++) {
+    // find the type and value inputs for each data type, ignoring hidden or "__prefix__"
+    typeQuery = `[name^=${valuesToCheck[i]}s][name$="type"]:not([name*="prefix"])`;
+    valueQuery = `[name^=${valuesToCheck[i]}s][name$="value"]:not([name*="prefix"])`;
+    typesNodes = Array.from(document.querySelectorAll(typeQuery));
+    valuesNodes = Array.from(document.querySelectorAll(valueQuery));
+    // get array of values from each for easier iterating
+    types = [];
+    values = [];
+    for (let j = 0; j < typesNodes.length; j++) {
+      types.push(typesNodes[j].value);
+      values.push(valuesNodes[j].value);
+    }
+    // for each qualifier, check if it's repeated
+    for (let j = 0; j < types.length; j++) {
+      duplicateTypeIndices = [];
+      types.filter(function (element, index) {
+        if (element == types[j]) {
+          duplicateTypeIndices.push(index);
         }
-        // for each qualifier, check if it's repeated
-        for (let j = 0; j < types.length; j++) {
-            duplicateTypeIndices = []
-            types.filter(function(element, index) {
-                if(element == types[j]) {
-                  duplicateTypeIndices.push(index)
-                }
-            })
+      });
 
-            // if we have more than 1 of the same qualifier:
-            // check if any values at the same indices are duplicates
-            potentialDuplicateValues = []
-            if (duplicateTypeIndices.length > 1){
-                for (let k = 0; k < duplicateTypeIndices.length; k++){
-                    potentialDuplicateValues.push(values[duplicateTypeIndices[k]]) 
-                 }
-                 valuesSet = new Set(potentialDuplicateValues)
-                 if (valuesSet.size != potentialDuplicateValues.length){
-                     alert(`Duplicate qualifier and value found for ${formattedNames[i]}.`)
-                     return false
-                 }
-            }         
+      // if we have more than 1 of the same qualifier:
+      // check if any values at the same indices are duplicates
+      potentialDuplicateValues = [];
+      if (duplicateTypeIndices.length > 1) {
+        for (let k = 0; k < duplicateTypeIndices.length; k++) {
+          potentialDuplicateValues.push(values[duplicateTypeIndices[k]]);
         }
+        valuesSet = new Set(potentialDuplicateValues);
+        if (valuesSet.size != potentialDuplicateValues.length) {
+          alert(
+            `Duplicate qualifier and value found for ${formattedNames[i]}.`
+          );
+          return false;
+        }
+      }
     }
-    // simplified check for language, which has no qualifier
-    langValueQuery=`[name^="languages"][name$="value"]:not([name*="prefix"])`
-    langNodes = document.querySelectorAll(langValueQuery)
-    languages = []
-    for (let i = 0; i < langNodes.length; i++) {
-        languages.push(langNodes[i].value)
-    }
-    langSet = new Set(languages)
-    if (langSet.size != languages.length){
-        alert("Duplicate value found for Language.")
-        return false
-    }
-    return true
+  }
+  // simplified check for language, which has no qualifier
+  langValueQuery = `[name^="languages"][name$="value"]:not([name*="prefix"])`;
+  langNodes = document.querySelectorAll(langValueQuery);
+  languages = [];
+  for (let i = 0; i < langNodes.length; i++) {
+    languages.push(langNodes[i].value);
+  }
+  langSet = new Set(languages);
+  if (langSet.size != languages.length) {
+    alert("Duplicate value found for Language.");
+    return false;
+  }
+  return true;
 }
 
 function validateSearchForm() {
-    if (document.getElementById("id_search_type").value == "status") {
-        if (document.getElementById("id_status_query").value == "") {
-            alert("Please select a Status value.")
-            return false
-        }
+  if (document.getElementById("id_search_type").value == "status") {
+    if (document.getElementById("id_status_query").value == "") {
+      alert("Please select a Status value.");
+      return false;
     }
-    else {
-        if (document.getElementById("id_char_query").value.trim().length === 0 ) {
-            alert("Please enter a search query.")
-            return false
-        }
+  } else {
+    if (document.getElementById("id_char_query").value.trim().length === 0) {
+      alert("Please enter a search query.");
+      return false;
     }
+  }
+  if (
+    document.getElementById("id_char_query").value === "*" &&
+    document.getElementById("id_item_type_filter").value === "" &&
+    document.getElementById("id_media_file_type_filter").value === ""
+  ) {
+    alert("To use wildcard search, please use at least one filter.");
+    return false;
+  }
 }


### PR DESCRIPTION
Implements [SYS-1632](https://uclalibrary.atlassian.net/browse/SYS-1632) (mostly)

This PR adds two new functionalities to item search, which I believe satisfy [Lisa's requests](https://uclalibrary.atlassian.net/wiki/spaces/DEV/pages/276529172/OH+Staff+UI+Phase+3):
* Search filters for Item Type and Media File type. These can be used in conjunction with any search type to return only items with the specified Item Type or with attached Media Files of the specified type.
* Wildcard search. Searching for `*` will now return all items matching the filters. There is some simple JS validation to prevent users from performing a wildcard search without any filters (though the URL path `search_results/title/all/all/*` still exists and works).

I also have a few questions:
* This PR does not support one feature requested in the ticket: multiple selection for the item type filter. If this is really needed, I can implement this in the current search interface. It will increase the complexity of the URL parsing somewhat. 
* Should these searches be implemented using query strings instead of explicit URL paths? I feel like I usually see search URLs that look more like `search_results/title?itemtype=PDF&filetype=Interview&query=example` than my implementation of `search_results/title/PDF/Interview/example`. I'm not sure what the advantages of either approach are though.
* In Phase 2, we went to some lengths to make Status search mutually exclusive with Title, Keyword, or ARK search. I don't see why this is needed, and I think Status could easily be treated as another search filter alongside Item Type and Media File Tye. Do you think this should be added to this PR (or done in a separate ticket)?

[SYS-1632]: https://uclalibrary.atlassian.net/browse/SYS-1632?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ