### PR TITLE
SYS-1674: security fixes for OH Staff UI

### DIFF
--- a/.github/workflows/build_docker_hub.yml
+++ b/.github/workflows/build_docker_hub.yml
@@ -11,13 +11,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
       
       - name: Login to DockerHub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -33,8 +33,10 @@ jobs:
         run: echo "${{ steps.yaml-data.outputs.data }}"
 
       - name: Build and push
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v6
         with:
           context: .
           push: true
-          tags: uclalibrary/oral-history-staff-ui:${{ steps.yaml-data.outputs.data }}
+          tags: |
+            uclalibrary/oral-history-staff-ui:${{ steps.yaml-data.outputs.data }}
+            uclalibrary/oral-history-staff-ui:scan

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim-bullseye
+FROM python:3.12-slim-bookworm
 
 # Debian repository management
 RUN apt-get update

--- a/charts/prod-ohstaff-values.yaml
+++ b/charts/prod-ohstaff-values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: uclalibrary/oral-history-staff-ui
-  tag: v1.1.12
+  tag: v1.1.13
   pullPolicy: Always
 
 nameOverride: ""

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.1"
 services:
   django:
     build: .

--- a/docker-compose_REMOTE.yml
+++ b/docker-compose_REMOTE.yml
@@ -1,4 +1,3 @@
-version: "3.1"
 services:
   django:
     build: .

--- a/oh_staff_ui/templates/oh_staff_ui/release_notes.html
+++ b/oh_staff_ui/templates/oh_staff_ui/release_notes.html
@@ -3,6 +3,13 @@
 {% block content %}
 <h3>Release Notes</h3>
 <hr/>
+<h4>1.1.13</h4>
+<p><i>September 6, 2024</i></p>
+<ul>
+   <li>Updated Python to version 3.12 and Debian to version 12 (Bookworm).</li>
+   <li>Updated Django to version 4.2.16.</li>
+</ul>
+
 <h4>1.1.12</h4>
 <p><i>June 17, 2024</i></p>
 <ul>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django == 4.2.11
+Django == 4.2.16
 psycopg2 == 2.9.5
 gunicorn == 22.0.0
 whitenoise == 6.0.0
@@ -6,5 +6,7 @@ requests == 2.32.2
 pillow == 10.3.0
 ffmpeg-python == 0.2.0
 eulxml == 1.1.3
+# eulxml requires pkg_resources, which is distributed with setuptools
+setuptools== 74.1.2 
 ply == 3.11
 django-bootstrap5 == 23.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,6 @@ pillow == 10.3.0
 ffmpeg-python == 0.2.0
 eulxml == 1.1.3
 # eulxml requires pkg_resources, which is distributed with setuptools
-setuptools== 74.1.2 
+setuptools== 74.1.2
 ply == 3.11
 django-bootstrap5 == 23.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 Django == 4.2.16
 psycopg2 == 2.9.5
-gunicorn == 22.0.0
-whitenoise == 6.0.0
+gunicorn == 23.0.0
+whitenoise == 6.5.0
 requests == 2.32.2
 pillow == 10.3.0
 ffmpeg-python == 0.2.0


### PR DESCRIPTION
Implements [SYS-1674](https://uclalibrary.atlassian.net/browse/SYS-1674)
Upgrades without functionality changes. Includes:

* Base image updated to use Debian 12 and Python 3.12
* Django updated to 4.2.16, addressing [Dependabot alerts](https://github.com/UCLALibrary/oral-history-staff-ui/security/dependabot)
* Added new package to `requirements.txt`. `eulxml` requires the `pkg_resources` module, which is distributed with `setuptools`, which was included in Python 3.11 but not in 3.12
* Removed version declaration from docker-compose files
* Updated workflows to use latest actions versions and add scan tag to Docker Hub image
* Updated release notes and tag bump for deployment

Build logs should be clean: `docker compose --progress plain build > build.log`

112 tests should pass: `docker-compose exec django python manage.py test`

The [application](http://127.0.0.1:8000/) and [admin interface](http://127.0.0.1:8000/admin/) should allow login with dev_admin/dev_admin, and you should be able to use all existing functionality.

[SYS-1674]: https://uclalibrary.atlassian.net/browse/SYS-1674?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ