### PR TITLE
SYS-1753: Update Django to 4.2.19 to patch security issues and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,9 +80,9 @@ The container runs via `docker_scripts/entrypoint.sh`, which
    $ docker-compose exec django python manage.py loaddata --app oh_staff_ui seed-data
    #
    # Load full set of item data
-   $ docker-compose exec django python manage.py import_projectitems export_scripts/project-items-export.tsv
+   $ docker-compose exec django python manage.py import_projectitems migration_data/project-items-export.tsv
    # Load full set of name data
-   $ docker-compose exec django python manage.py import_names export_scripts/Name.tsv
+   $ docker-compose exec django python manage.py import_names migration_data/Name.tsv
    ```
 7. Connect to the running application via browser
 

--- a/charts/prod-ohstaff-values.yaml
+++ b/charts/prod-ohstaff-values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: uclalibrary/oral-history-staff-ui
-  tag: v1.1.13
+  tag: v1.1.14
   pullPolicy: Always
 
 nameOverride: ""

--- a/oh_staff_ui/templates/oh_staff_ui/release_notes.html
+++ b/oh_staff_ui/templates/oh_staff_ui/release_notes.html
@@ -3,6 +3,12 @@
 {% block content %}
 <h3>Release Notes</h3>
 <hr/>
+<h4>1.1.14</h4>
+<p><i>February 28, 2025</i></p>
+<ul>
+   <li>Updated Django to version 4.2.19 to patch security issues.</li>
+</ul>
+
 <h4>1.1.13</h4>
 <p><i>September 6, 2024</i></p>
 <ul>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django == 4.2.16
+Django == 4.2.19
 psycopg2 == 2.9.5
 gunicorn == 23.0.0
 whitenoise == 6.5.0


### PR DESCRIPTION
Implements [SYS-1753](https://uclalibrary.atlassian.net/browse/SYS-1753)

- Updated Django to 4.2.19 to patch security issues
- Bumped Helm chart version tag
- Added release note
- Updated `README.md`
    - **Note:** the steps given to import data pointed to the `export_scripts` directory, but it looks like those data files are actually under `migration_data`)

**Testing**
✅ All tests passed in dev environment


[SYS-1753]: https://uclalibrary.atlassian.net/browse/SYS-1753?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ