### PR TITLE
SYS-1829: Update Django, Python, and PostgreSQL

### DIFF
--- a/.docker-compose_db.env
+++ b/.docker-compose_db.env
@@ -9,7 +9,7 @@
 ###
 
 # Used in settings.py
-DJANGO_DB_BACKEND=django.db.backends.postgresql_psycopg2
+DJANGO_DB_BACKEND=django.db.backends.postgresql
 DJANGO_DB_HOST=db
 DJANGO_DB_PORT=5432
 DJANGO_DB_NAME=oral_history

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-slim-bookworm
+FROM python:3.13-slim-bookworm
 
 # Debian repository management
 RUN apt-get update
@@ -6,7 +6,7 @@ RUN apt-get update
 # Set correct timezone
 RUN ln -sf /usr/share/zoneinfo/America/Los_Angeles /etc/localtime
 
-# Install dependencies needed to build psycopg2 python module,
+# Install dependencies needed to build psycopg python module,
 # along with ffmpeg
 RUN apt-get install -y gcc python3-dev libpq-dev ffmpeg
 

--- a/charts/prod-ohstaff-values.yaml
+++ b/charts/prod-ohstaff-values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: uclalibrary/oral-history-staff-ui
-  tag: v1.1.14
+  tag: v1.1.15
   pullPolicy: Always
 
 nameOverride: ""
@@ -46,7 +46,7 @@ django:
       - https://oh-staff.library.ucla.edu
     ark_minter: "http://noid.library.ucla.edu/noidu_zz8+?mint+1"
     # Now pointing to production db
-    db_backend: "django.db.backends.postgresql_psycopg2"
+    db_backend: "django.db.backends.postgresql_psycopg"
     db_host: "p-d-postgres.library.ucla.edu"
     db_port: 5432
     db_name: "oral_history_staff"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       # For access to remote database via ssh tunnel on host
       - "host.docker.internal:host-gateway"
   db:
-    image: postgres:12
+    image: postgres:16
     env_file:
       - .docker-compose_db.env
     volumes:

--- a/docker_scripts/entrypoint.sh
+++ b/docker_scripts/entrypoint.sh
@@ -11,7 +11,7 @@ fi
 
 # Check when database is ready for connections
 echo "Checking database connectivity..."
-until python -c 'import os, psycopg2 ; conn = psycopg2.connect(host=os.environ.get("DJANGO_DB_HOST"),port=os.environ.get("DJANGO_DB_PORT"),user=os.environ.get("DJANGO_DB_USER"),password=os.environ.get("DJANGO_DB_PASSWORD"),dbname=os.environ.get("DJANGO_DB_NAME"))' ; do
+until python -c 'import os, psycopg ; conn = psycopg.connect(host=os.environ.get("DJANGO_DB_HOST"),port=os.environ.get("DJANGO_DB_PORT"),user=os.environ.get("DJANGO_DB_USER"),password=os.environ.get("DJANGO_DB_PASSWORD"),dbname=os.environ.get("DJANGO_DB_NAME"))' ; do
   echo "Database connection not ready - waiting"
   sleep 5
 done

--- a/oh_staff_ui/templates/oh_staff_ui/base.html
+++ b/oh_staff_ui/templates/oh_staff_ui/base.html
@@ -23,7 +23,11 @@
         <li><a href="/admin/">Admin (Metadata Configuration)</a></li>
         <li><a href="/logs/">Logs</a></li>
         <li><a href="/release_notes/">Release Notes</a></li>
-        <li><a href="/admin/logout/">Logout</a></li>
+        <li><form action="{% url 'logout' %}" method="post">
+            {% csrf_token %}
+            {% bootstrap_button "Logout" button_type="submit" button_class="link-primary" %}
+        </form>
+        </li>
     </ul>
     <br>
     <div class="container">

--- a/oh_staff_ui/templates/oh_staff_ui/release_notes.html
+++ b/oh_staff_ui/templates/oh_staff_ui/release_notes.html
@@ -3,6 +3,14 @@
 {% block content %}
 <h3>Release Notes</h3>
 <hr/>
+
+<h4>1.1.15</h4>
+<p><i>May 15, 2025</i></p>
+<ul>
+   <li>Updated Django to 5.2.1.</li>
+   <li>Updated psycopg to support PostgreSQL 16.</li>
+</ul>
+
 <h4>1.1.14</h4>
 <p><i>February 28, 2025</i></p>
 <ul>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
-Django == 4.2.19
-psycopg2 == 2.9.5
+Django == 5.2.1
+psycopg == 3.2.9
 gunicorn == 23.0.0
 whitenoise == 6.5.0
 requests == 2.32.2
-pillow == 10.3.0
+pillow == 11.2.1
 ffmpeg-python == 0.2.0
 eulxml == 1.1.3
 # eulxml requires pkg_resources, which is distributed with setuptools

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -13,11 +13,19 @@ ul.navbar {
   border-right: 1px solid #bcbcc5;
 }
 
-.navbar li a {
+.navbar li a,
+.navbar li button {
   display: block;
   text-align: center;
-  padding: 10px 12px;
   text-decoration: none;
+}
+
+.navbar li a {
+  padding: 10px 12px;
+}
+
+.navbar li form {
+  height: 24px;
 }
 
 td.search-type {

--- a/templates/admin/base_site.html
+++ b/templates/admin/base_site.html
@@ -11,4 +11,4 @@
 <h1 id="site-name"><a href="{% url 'admin:index' %}">Oral History Administration</a></h1>
 {% endblock %}
 
-{% block nav-global %}<a href="{{ site_url }}">Main Oral History Staff Interface</a>{% endblock %}
+{% block nav-global %}<a href="{% url 'item_search' %}">Main Oral History Staff Interface</a>{% endblock %}


### PR DESCRIPTION
Implements [SYS-1829](https://uclalibrary.atlassian.net/browse/SYS-1829)

Includes necessary changes to upgrade to Django 5.2, Python 13, and PostgreSQL 16.

* `psycopg2` is replaced by `psycopg`
* `pillow` is updated to version 11.2.1 to support Python 13
*  Release notes are updated, and tag is bumped for deployment

Code changes in the app are all related to logout functionality. Per the [5.0 release notes](https://docs.djangoproject.com/en/5.2/releases/5.0/), "Support for logging out via GET requests in the django.contrib.auth.views.LogoutView and django.contrib.auth.views.logout_then_login() is removed." Therefore, `oh_staff_ui/templates/oh_staff_ui/base.html` is updated to change the "Logout" link to a form with a button that submits a POST request to the logout view. CSS is updated in `static/css/style.css` to style this button to look like a link, so the appearance of the app should not change. I also noticed that I needed to update the admin `base_site` template to fix the "Main Oral History Staff Interface" link, which was broken on logout pages. I'm less sure why this change was needed.

@henry-r18, FYI - this is one approach to fixing the logout issue.

### Testing
Remove old DB volume, if applicable
`docker volume rm oral-history-staff-ui_pg_data `

Build containers and bring them up
`docker compose build`
`docker compose up -d`

Run tests - 122 tests should pass
`docker compose exec django python manage.py test`

Check out the [Application](http://127.0.0.1:8000/) and [Admin](http://127.0.0.1:8000/admin) in browser - default superuser is dev_admin/dev_admin


[SYS-1829]: https://uclalibrary.atlassian.net/browse/SYS-1829?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ