### PR TITLE
SYS-2014: apply security updates

### DIFF
--- a/charts/prod-ohstaff-values.yaml
+++ b/charts/prod-ohstaff-values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: uclalibrary/oral-history-staff-ui
-  tag: v1.1.16
+  tag: v1.1.17
   pullPolicy: Always
 
 nameOverride: ""

--- a/oh_staff_ui/templates/oh_staff_ui/release_notes.html
+++ b/oh_staff_ui/templates/oh_staff_ui/release_notes.html
@@ -4,6 +4,12 @@
 <h3>Release Notes</h3>
 <hr/>
 
+<h4>1.1.17</h4>
+<p><i>September 18, 2025</i></p>
+<ul>
+   <li>Upgrade Python packages (Django, requests, pillow, and setuptools).</li>
+</ul>
+
 <h4>1.1.16</h4>
 <p><i>May 16, 2025</i></p>
 <ul>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,12 @@
-Django == 5.2.1
+Django == 5.2.6
 psycopg == 3.2.9
 gunicorn == 23.0.0
 whitenoise == 6.5.0
-requests == 2.32.2
-pillow == 11.2.1
+requests == 2.32.5
+pillow == 11.3.0
 ffmpeg-python == 0.2.0
 eulxml == 1.1.3
 # eulxml requires pkg_resources, which is distributed with setuptools
-setuptools== 74.1.2
+setuptools== 80.9.0
 ply == 3.11
 django-bootstrap5 == 23.1


### PR DESCRIPTION
Implements [SYS-2014](https://uclalibrary.atlassian.net/browse/SYS-2014)

Upgrades versions of Django, pillow, setuptools, and requests, addressing all current [dependabot alerts](https://github.com/UCLALibrary/oral-history-staff-ui/security/dependabot) for this repo.

Also includes release notes and tag bump for deployment.

[SYS-2014]: https://uclalibrary.atlassian.net/browse/SYS-2014?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ