### PR TITLE
SYS-2132: Update Django to 5.2.10 to patch security issues

### DIFF
--- a/charts/prod-ohstaff-values.yaml
+++ b/charts/prod-ohstaff-values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: uclalibrary/oral-history-staff-ui
-  tag: v1.1.17
+  tag: v1.1.18
   pullPolicy: Always
 
 nameOverride: ""

--- a/oh_staff_ui/templates/oh_staff_ui/release_notes.html
+++ b/oh_staff_ui/templates/oh_staff_ui/release_notes.html
@@ -4,6 +4,12 @@
 <h3>Release Notes</h3>
 <hr/>
 
+<h4>1.1.18</h4>
+<p><i>January 7, 2026</i></p>
+<ul>
+   <li>Upgrade Django to 5.2.10 to patch security issues.</li>
+</ul>
+
 <h4>1.1.17</h4>
 <p><i>September 18, 2025</i></p>
 <ul>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django == 5.2.6
+Django == 5.2.10
 psycopg == 3.2.9
 gunicorn == 23.0.0
 whitenoise == 6.5.0


### PR DESCRIPTION
Implements [SYS-2132](https://uclalibrary.atlassian.net/browse/SYS-2132)

All 112 tests still pass after updating Django to 5.2.10: `docker compose exec django python manage.py test`

[SYS-2132]: https://uclalibrary.atlassian.net/browse/SYS-2132?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ